### PR TITLE
SBC: WS CANCEL fix + KAMAILIO_IP→SBC_IP rename + curl-pipe installer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,18 +23,27 @@ SMTP_URL=smtp://username:password@mail.example.com:587
 INTERNAL_API_BASE_URL=replaceMe
 INTERNAL_API_USERNAME=internal_api
 INTERNAL_API_PASSWORD=replaceMe
-OPENAI_FUNCTION_API_KEY=replaceMe # this is used during dev and integration test to see how voice bot uses api
 DEEPGRAM_API_KEY=replaceMe
-KAMAILIO_SIP_URI=replaceMe
 OPENAI_API_KEY=replaceMe
 ENV=replaceMe
-FS_LOCAL_NETWORK=replaceMe                       # Any SIP request from this network will be considered local and use private ip for sip and rtp
 REDIS_URL=redis://redis
 DEV_IP=replaceMe # This is dev machine IP, used for local development
+# Comma-separated CIDRs added as ALLOW rules to FreeSWITCH's "private" ACL.
+# Anything matching is treated as local (rtp-ip used in SDP). Typically the
+# docker subnet that FS shares with the SBC and any local peers.
+# Example: 172.31.0.0/16
+FS_LOCAL_NETWORK=replaceMe
 DEV_RABBITMQ_USERNAME=replaceMe
 DEV_RABBITMQ_PASSWORD=replaceMe
 RPC_API_TOKEN=replaceMe
-KAMAILIO_IP=replaceMe
-KAMAILIO_IPS=replaceMe
+# IP address of the SBC (in-tree Go SBC; Kamailio in EE-style setups). Single
+# source of truth used everywhere:
+#   - dial_utils derives fs_path=sip:<IP>:5065 for FreeSWITCH outbound routing
+#   - acl.conf denies <IP>/32 in the "private" list so FS treats the SBC as
+#     non-local and advertises ext-rtp-ip in SDP (real media endpoint reached
+#     via host NAT, not the SBC's docker IP)
+#   - SBC RPC uses http://<IP>/rpc for control-plane calls
+# A bare IP is treated as /32 in the ACL; pass a CIDR (e.g. 10.0.0.0/24) to widen.
+SBC_IP=replaceMe
 SECRET_KEY_BASE=replaceMe # used by phoenix library
 CLUSTER_STRATEGY=replaceMe

--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -116,8 +116,11 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-comcent}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-comcent}
       REDIS_URL: redis://redis:6379
       RABBITMQ_URL: amqp://${RABBITMQ_USER:-comcent}:${RABBITMQ_PASSWORD}@rabbitmq
-      # SBC is the in-tree Go SBC replacing Kamailio in CE
-      KAMAILIO_SIP_URI: sip:${COMCENT_DOMAIN}
+      # In-tree Go SBC's pinned IP — dial_utils derives fs_path=sip:<IP>:5065
+      # from this, FreeSWITCH ACL denies it (so SBC traffic is treated as
+      # non-local and ext-rtp-ip is used in SDP), and kamailio_rpc.ex uses
+      # http://<IP>/rpc for control-plane calls.
+      SBC_IP: ${SBC_IP:-172.20.0.10}
       CLUSTER_STRATEGY: gossip
       POSTGRES_SSL_ENABLED: 'false'
     depends_on:
@@ -215,8 +218,10 @@ services:
         condition: service_healthy
       cert-dumper:
         condition: service_started
+    # Pinned IP — server's SBC_IP env and FreeSWITCH ACL reference this.
     networks:
-      - comcent-network
+      comcent-network:
+        ipv4_address: 172.20.0.10
 
   # ---------------------------------------------------------------------------
   # Cert dumper — watches Traefik's acme.json and writes per-domain PEM files
@@ -274,8 +279,11 @@ services:
         condition: service_healthy
       sbc:
         condition: service_started
+    # Pinned IP — referenced by FreeSWITCH ACL allow rules (FS_LOCAL_NETWORK)
+    # and the SBC dispatcher's auto-discovery.
     networks:
-      - comcent-network
+      comcent-network:
+        ipv4_address: 172.20.0.11
 
   # ---------------------------------------------------------------------------
   # Voice bot (AI) — OPTIONAL. Uncomment to enable real-time AI voice agent.
@@ -299,6 +307,9 @@ networks:
   comcent-network:
     name: comcent-network
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
 
 volumes:
   postgres_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -242,8 +242,6 @@ services:
       - ./fsdata:/usr/local/freeswitch/sounds
     ports:
       - '18000-18100:18000-18100/udp'
-    networks:
-      - comcent-network
     environment:
       - SOUND_RATES=8000:32000
       - SOUND_TYPES=music:en-us-callie
@@ -272,6 +270,12 @@ services:
         condition: service_started
       minio-init:
         condition: service_started
+    # Pin FS to a static IP so the FreeSWITCH ACL ("private" list) and
+    # SBC dispatcher can reference a known address rather than whatever
+    # docker happens to hand out on each restart.
+    networks:
+      comcent-network:
+        ipv4_address: 172.31.0.11
 
 networks:
   comcent-network:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# Comcent CE installer — one-shot bootstrap for a fresh Linux host.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/comcent-io/comcent-ce/main/install.sh | bash
+#
+# What it does:
+#   1. Verifies Docker + curl + openssl.
+#   2. Detects the host's public IP.
+#   3. Prompts for things we cannot guess (domain, email, SMTP, S3 creds, etc.).
+#   4. Generates strong random secrets for DB / RabbitMQ / API / signing.
+#   5. Downloads docker-compose.deploy.yaml as docker-compose.yaml.
+#   6. Writes .env (mode 600) and starts the stack.
+#
+# Re-running on a host that already has .env is refused — move it aside first.
+
+set -euo pipefail
+
+BRANCH="${COMCENT_BRANCH:-main}"
+REPO_RAW="https://raw.githubusercontent.com/comcent-io/comcent-ce/${BRANCH}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/comcent-ce}"
+
+# ---------- output helpers --------------------------------------------------
+if [ -t 1 ]; then
+  R=$'\033[1;31m'; G=$'\033[1;32m'; Y=$'\033[1;33m'; B=$'\033[1;34m'; N=$'\033[0m'
+else
+  R=""; G=""; Y=""; B=""; N=""
+fi
+info()  { printf "%s[*]%s %s\n" "$B" "$N" "$*"; }
+ok()    { printf "%s[✓]%s %s\n" "$G" "$N" "$*"; }
+warn()  { printf "%s[!]%s %s\n" "$Y" "$N" "$*"; }
+die()   { printf "%s[x]%s %s\n" "$R" "$N" "$*" >&2; exit 1; }
+
+# ---------- TTY for prompts when piped from curl ----------------------------
+# When run as `curl … | bash`, stdin is the script bytes. Reattach to /dev/tty
+# so `read` can prompt the operator.
+if [ ! -t 0 ]; then
+  if [ -e /dev/tty ]; then
+    exec </dev/tty
+  else
+    die "Interactive prompts require a TTY. Run on a real shell, not a non-interactive runner."
+  fi
+fi
+
+# ---------- prereqs ---------------------------------------------------------
+need() { command -v "$1" >/dev/null 2>&1 || die "Missing prerequisite: $1"; }
+need docker
+need curl
+need openssl
+docker compose version >/dev/null 2>&1 \
+  || die "docker compose plugin required (Docker 24+). On Ubuntu: 'apt install docker-compose-plugin'."
+
+# ---------- detect host's public IP -----------------------------------------
+detect_ip() {
+  curl -fsS --max-time 5 https://api.ipify.org   2>/dev/null \
+    || curl -fsS --max-time 5 https://ifconfig.me 2>/dev/null \
+    || curl -fsS --max-time 5 https://icanhazip.com 2>/dev/null \
+    || true
+}
+PUBLIC_IP_DETECTED="$(detect_ip)"
+
+# ---------- random secret helpers -------------------------------------------
+rand_url() { openssl rand -base64 48 | tr -d '\n+/=' | head -c 32; }
+rand_b64() { openssl rand -base64 64 | tr -d '\n'; }
+rand_hex() { openssl rand -hex 32; }
+
+# ---------- prompt helpers --------------------------------------------------
+prompt() {
+  # prompt VAR LABEL [DEFAULT]
+  local __var="$1" __label="$2" __default="${3:-}" __reply
+  if [ -n "$__default" ]; then
+    printf "  %s [%s]: " "$__label" "$__default"
+  else
+    printf "  %s: " "$__label"
+  fi
+  IFS= read -r __reply || __reply=""
+  [ -z "$__reply" ] && __reply="$__default"
+  printf -v "$__var" "%s" "$__reply"
+}
+
+prompt_required() {
+  # prompt_required VAR LABEL
+  local __var="$1" __label="$2" __reply=""
+  while [ -z "$__reply" ]; do
+    printf "  %s: " "$__label"
+    IFS= read -r __reply || __reply=""
+    [ -z "$__reply" ] && warn "value required, please enter something"
+  done
+  printf -v "$__var" "%s" "$__reply"
+}
+
+# ---------- banner ----------------------------------------------------------
+cat <<BANNER
+
+${B}=============================================================${N}
+  Comcent CE — open-source contact center installer
+${B}=============================================================${N}
+Install dir: ${INSTALL_DIR}
+BANNER
+
+mkdir -p "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+[ -f .env ] && die ".env already exists in $INSTALL_DIR — refusing to overwrite. Move it aside or set INSTALL_DIR=…"
+
+echo
+info "We need a few things to set this up. Press enter to accept defaults shown in [brackets]."
+echo
+
+# ---------- required identity -----------------------------------------------
+prompt_required COMCENT_DOMAIN   "Public domain (DNS A record must already point here)"
+prompt PUBLIC_IP                 "Public IP (used by FreeSWITCH for SDP)"          "$PUBLIC_IP_DETECTED"
+[ -z "$PUBLIC_IP" ] && die "PUBLIC_IP could not be detected and you didn't supply one."
+
+prompt LETSENCRYPT_EMAIL         "Let's Encrypt contact email"                     "admin@${COMCENT_DOMAIN}"
+prompt SOURCE_EMAIL              "Outbound sender (invites, password resets)"      "Comcent <noreply@${COMCENT_DOMAIN}>"
+prompt SIP_WSS_PORT              "SIP-over-WSS host port"                          "5063"
+
+# ---------- SMTP ------------------------------------------------------------
+echo
+info "SMTP for transactional email. Leave empty to skip (invites/password resets won't be sent)."
+prompt SMTP_URL "SMTP URL (smtp://user:pass@host:587)" ""
+
+# ---------- object storage --------------------------------------------------
+echo
+info "Object storage for call recordings & uploads (S3 or any S3-compatible)."
+prompt_required STORAGE_BUCKET_NAME    "Bucket name"
+prompt          BUCKET_REGION          "Region"                                   "us-east-1"
+prompt_required AWS_ACCESS_KEY_ID      "Access key id"
+prompt_required AWS_SECRET_ACCESS_KEY  "Secret access key"
+prompt          S3_ENDPOINT_URL        "S3 endpoint URL (blank = AWS S3)"          ""
+
+# ---------- AI keys ---------------------------------------------------------
+echo
+info "Optional AI features (transcription, summaries, voice bot). Leave empty to skip."
+prompt DEEPGRAM_API_KEY "Deepgram API key" ""
+prompt OPENAI_API_KEY   "OpenAI API key"   ""
+
+# ---------- generated secrets -----------------------------------------------
+POSTGRES_PASSWORD="$(rand_url)"
+RABBITMQ_PASSWORD="$(rand_url)"
+INTERNAL_API_PASSWORD="$(rand_url)"
+RPC_API_TOKEN="$(rand_url)"
+SECRET_KEY_BASE="$(rand_b64)"
+SIGNING_KEY="$(rand_hex)"
+
+echo
+info "Generated random secrets for postgres, rabbitmq, internal API, RPC token, and signing keys."
+
+# ---------- download compose ------------------------------------------------
+info "Downloading docker-compose.deploy.yaml from ${REPO_RAW}…"
+curl -fsSL "${REPO_RAW}/docker-compose.deploy.yaml" -o docker-compose.yaml \
+  || die "Failed to download docker-compose.deploy.yaml"
+ok "docker-compose.yaml saved."
+
+# ---------- write .env ------------------------------------------------------
+info "Writing .env (mode 600)…"
+umask 077
+cat > .env <<EOF
+# Comcent CE — generated by install.sh on $(date -u +%Y-%m-%dT%H:%M:%SZ)
+# Edit at will, but keep this file out of source control.
+
+# --- identity / networking ---
+COMCENT_DOMAIN=${COMCENT_DOMAIN}
+PUBLIC_IP=${PUBLIC_IP}
+LETSENCRYPT_EMAIL=${LETSENCRYPT_EMAIL}
+SOURCE_EMAIL=${SOURCE_EMAIL}
+SIP_WSS_PORT=${SIP_WSS_PORT}
+
+# --- image tags ---
+COMCENT_VERSION=latest
+FREESWITCH_VERSION=latest
+
+# --- service-to-service ---
+# SBC pinned IP from docker-compose. dial_utils derives sip:<IP>:5065 from this;
+# the same value drives the FS ACL deny rule and the SBC RPC URL.
+SBC_IP=172.20.0.10
+# Docker subnet — added as ALLOW in FS's "private" ACL so internal peers stay local.
+FS_LOCAL_NETWORK=172.20.0.0/16
+
+INTERNAL_API_USERNAME=internal_api
+INTERNAL_API_PASSWORD=${INTERNAL_API_PASSWORD}
+RPC_API_TOKEN=${RPC_API_TOKEN}
+
+# --- data services ---
+POSTGRES_USER=comcent
+POSTGRES_DB=comcent
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+RABBITMQ_USER=comcent
+RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
+
+# --- secrets ---
+SECRET_KEY_BASE=${SECRET_KEY_BASE}
+SIGNING_KEY=${SIGNING_KEY}
+
+# --- storage ---
+STORAGE_BUCKET_NAME=${STORAGE_BUCKET_NAME}
+BUCKET_REGION=${BUCKET_REGION}
+AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+S3_ENDPOINT_URL=${S3_ENDPOINT_URL}
+S3_PROXY_DOWNLOADS=false
+
+# --- auth ---
+AUTH_PASSWORD_ENABLED=true
+AUTH_OIDC_PROVIDERS_JSON={}
+
+# --- email ---
+SMTP_URL=${SMTP_URL}
+
+# --- AI (optional) ---
+DEEPGRAM_API_KEY=${DEEPGRAM_API_KEY}
+OPENAI_API_KEY=${OPENAI_API_KEY}
+
+# --- observability (optional) ---
+SERVER_SENTRY_DSN=
+PUBLIC_SENTRY_DSN=
+
+# --- runtime ---
+ENV=prod
+CLUSTER_STRATEGY=gossip
+EOF
+chmod 600 .env
+ok ".env written."
+
+# ---------- bring stack up --------------------------------------------------
+echo
+info "Pulling images (one-time download, several hundred MB)…"
+docker compose pull
+echo
+info "Starting stack…"
+docker compose up -d
+
+# ---------- summary ---------------------------------------------------------
+cat <<EOF
+
+${G}Comcent CE is starting.${N}
+
+Working directory : ${INSTALL_DIR}
+Domain            : https://${COMCENT_DOMAIN}
+Public IP         : ${PUBLIC_IP}
+
+Watch boot logs:
+  cd ${INSTALL_DIR} && docker compose logs -f server
+
+Open the app once Let's Encrypt finishes (1–2 min on first launch):
+  https://${COMCENT_DOMAIN}
+
+Required inbound firewall rules:
+  TCP 80, 443                 — HTTP/HTTPS (cert issuance + app)
+  UDP+TCP 5060                — SIP signaling
+  TCP 5061                    — SIP/TLS
+  TCP ${SIP_WSS_PORT}                    — SIP-over-WSS (browser dialer)
+  UDP 19000-19100             — RTP media
+
+Upgrade later:
+  cd ${INSTALL_DIR} && docker compose pull && docker compose up -d
+
+EOF

--- a/packages/web-app/src/lib/server/dialUtils.ts
+++ b/packages/web-app/src/lib/server/dialUtils.ts
@@ -1,6 +1,9 @@
 import { parsePhoneNumber } from 'libphonenumber-js';
 
-const KAMAILIO_SIP_URI = process.env.KAMAILIO_SIP_URI;
+const SBC_IP = process.env.SBC_IP;
+// Target the SBC's PRIVATE listener (5065). 5060 is the public/PSTN-facing
+// leg; sending FS outbound there would loop back through public routing.
+const SBC_SIP_URI = SBC_IP ? `sip:${SBC_IP}:5065` : '';
 const SIP_USER_ROOT_DOMAIN =
   process.env.SIP_USER_ROOT_DOMAIN ||
   (process.env.PUBLIC_BASE_URL ? new URL(process.env.PUBLIC_BASE_URL).hostname : undefined);
@@ -9,7 +12,7 @@ if (!SIP_USER_ROOT_DOMAIN) {
 }
 
 export function createDialStringForUser(username: string, subdomain: string) {
-  const dString = `sofia/internal/${username}@${subdomain}.${SIP_USER_ROOT_DOMAIN};fs_path=${KAMAILIO_SIP_URI}`;
+  const dString = `sofia/internal/${username}@${subdomain}.${SIP_USER_ROOT_DOMAIN};fs_path=${SBC_SIP_URI}`;
   return [dString, `[media_webrtc=true]${dString}`].join(',');
 }
 
@@ -28,7 +31,7 @@ export function createDialStringForSipTrunk(
   const variables = `[sip_h_X-Trunk-Number=${fromNumber},origination_caller_id_number=${
     adjustedSpoofedNumber || fromNumber
   }]`;
-  return `${variables}sofia/internal/${adjustedToNumber}@${trunkAddress};fs_path=${KAMAILIO_SIP_URI}`;
+  return `${variables}sofia/internal/${adjustedToNumber}@${trunkAddress};fs_path=${SBC_SIP_URI}`;
 }
 
 export function convertNumberToE164OrUs11(referenceNumber: string, numberToBeConverted: string) {

--- a/sbc/proxy.go
+++ b/sbc/proxy.go
@@ -450,12 +450,23 @@ func (p *Proxy) handleInviteFromFSToUser(req *sip.Request, tx sip.ServerTransact
 		cancelReq.AppendHeader(sip.HeaderClone(b.fwdReq.From()))
 		cancelReq.AppendHeader(sip.HeaderClone(b.fwdReq.To()))
 		cancelReq.AppendHeader(sip.HeaderClone(b.fwdReq.CallID()))
+		// RFC 3261 §9.1: CANCEL CSeq mirrors INVITE's SeqNo with Method=CANCEL.
+		// Max-Forwards is also mandatory.
+		if cseq := b.fwdReq.CSeq(); cseq != nil {
+			cancelReq.AppendHeader(&sip.CSeqHeader{SeqNo: cseq.SeqNo, MethodName: sip.CANCEL})
+		}
+		mf := sip.MaxForwardsHeader(70)
+		cancelReq.AppendHeader(&mf)
 		sip.CopyHeaders("Route", b.fwdReq, cancelReq)
 		cancelReq.SetSource(b.fwdReq.Source())
 		cancelReq.SetDestination(b.fwdReq.Destination())
 		cancelReq.SetTransport(b.fwdReq.Transport())
-		if err := p.publicClient.WriteRequest(cancelReq); err != nil {
-			slog.Debug("CANCEL on fork sibling failed", "address", b.contact.Address, "error", err)
+		// Pass noopClientOption so sipgo skips clientRequestBuildReq, which
+		// would stamp req.Laddr with the public client's bind addr
+		// (0.0.0.0:5060) and break pooled-connection lookup — fatal for WS to
+		// the registered WebRTC agent (would try to bind 0.0.0.0:5060 again).
+		if err := p.publicClient.WriteRequest(cancelReq, noopClientOption); err != nil {
+			slog.Error("CANCEL on fork sibling failed", "address", b.contact.Address, "error", err)
 		}
 	}
 
@@ -944,14 +955,26 @@ func (p *Proxy) cancelOutgoing(callID string) {
 	cancelReq.AppendHeader(sip.HeaderClone(entry.req.From()))
 	cancelReq.AppendHeader(sip.HeaderClone(entry.req.To()))
 	cancelReq.AppendHeader(sip.HeaderClone(entry.req.CallID()))
+	if cseq := entry.req.CSeq(); cseq != nil {
+		cancelReq.AppendHeader(&sip.CSeqHeader{SeqNo: cseq.SeqNo, MethodName: sip.CANCEL})
+	}
+	mf := sip.MaxForwardsHeader(70)
+	cancelReq.AppendHeader(&mf)
 	sip.CopyHeaders("Route", entry.req, cancelReq)
 	cancelReq.SetSource(entry.req.Source())
 	cancelReq.SetDestination(entry.req.Destination())
 
-	if err := entry.client.WriteRequest(cancelReq); err != nil {
+	if err := entry.client.WriteRequest(cancelReq, noopClientOption); err != nil {
 		slog.Error("Failed to send CANCEL", "callid", callID, "error", err)
 	}
 }
+
+// noopClientOption is a do-nothing sipgo.ClientRequestOption. Passing any
+// option to WriteRequest causes sipgo to skip clientRequestBuildReq, which
+// otherwise stamps req.Laddr with the client's bind addr and breaks pooled
+// connection lookup for already-open inbound transports (notably WS to a
+// registered WebRTC agent).
+func noopClientOption(_ *sipgo.Client, _ *sip.Request) error { return nil }
 
 // ---------------------------------------------------------------------------
 // OPTIONS (respond locally)

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -228,11 +228,11 @@ else
   IO.puts("No Redis URL found")
 end
 
-# Kamailio RPC Configuration
-kamailio_ip =
-  System.get_env("KAMAILIO_IP") ||
+# SBC RPC Configuration (Kamailio in EE-style topologies; CE uses the in-tree Go SBC)
+sbc_ip =
+  System.get_env("SBC_IP") ||
     raise """
-    environment variable KAMAILIO_IP is missing.
+    environment variable SBC_IP is missing.
     For example: 192.168.1.100
     """
 
@@ -242,8 +242,8 @@ rpc_api_token =
     environment variable RPC_API_TOKEN is missing.
     """
 
-config :comcent, :kamailio,
-  ip: kamailio_ip,
+config :comcent, :sbc,
+  ip: sbc_ip,
   rpc_api_token: rpc_api_token
 
 # RabbitMQ Configuration

--- a/server/lib/comcent/dial_utils.ex
+++ b/server/lib/comcent/dial_utils.ex
@@ -16,10 +16,20 @@ defmodule Comcent.DialUtils do
   end
 
   def create_dial_targets_for_user(username, subdomain, channel_vars \\ nil) do
-    kamailio_sip_uri = System.get_env("KAMAILIO_SIP_URI") || ""
+    sbc_sip_uri = sbc_sip_uri()
     sip_user_root_domain = Application.fetch_env!(:comcent, :sip_user_root_domain)
-    base_dial = "sofia/internal/#{username}@#{subdomain}.#{sip_user_root_domain};fs_path=#{kamailio_sip_uri}"
+    base_dial = "sofia/internal/#{username}@#{subdomain}.#{sip_user_root_domain};fs_path=#{sbc_sip_uri}"
     build_user_dial_targets(base_dial, channel_vars)
+  end
+
+  # Target the SBC's PRIVATE listener (5065). 5060 is the public/PSTN-facing
+  # leg; sending FS outbound there would loop back through public routing.
+  defp sbc_sip_uri do
+    case System.get_env("SBC_IP") do
+      nil -> ""
+      "" -> ""
+      ip -> "sip:#{ip}:5065"
+    end
   end
 
   def user_dial_branch_count do
@@ -49,10 +59,10 @@ defmodule Comcent.DialUtils do
   ## Examples
 
       iex> Comcent.DialUtils.create_dial_string_for_sip_trunk("1234567890", "9876543210", "sip.example.com")
-      "[sip_h_X-Trunk-Number=1234567890,origination_caller_id_number=1234567890]sofia/internal/9876543210@sip.example.com;fs_path=kamailio_sip_uri"
+      "[sip_h_X-Trunk-Number=1234567890,origination_caller_id_number=1234567890]sofia/internal/9876543210@sip.example.com;fs_path=sbc_sip_uri"
 
       iex> Comcent.DialUtils.create_dial_string_for_sip_trunk("1234567890", "9876543210", "sip.example.com", "5555555555")
-      "[sip_h_X-Trunk-Number=1234567890,origination_caller_id_number=5555555555]sofia/internal/9876543210@sip.example.com;fs_path=kamailio_sip_uri"
+      "[sip_h_X-Trunk-Number=1234567890,origination_caller_id_number=5555555555]sofia/internal/9876543210@sip.example.com;fs_path=sbc_sip_uri"
   """
   def create_dial_string_for_sip_trunk(
         from_number,
@@ -60,7 +70,7 @@ defmodule Comcent.DialUtils do
         trunk_address,
         spoofed_number \\ nil
       ) do
-    kamailio_sip_uri = System.get_env("KAMAILIO_SIP_URI") || ""
+    sbc_sip_uri = sbc_sip_uri()
 
     # Convert numbers to E164 or US11 format
     adjusted_to_number = convert_number_to_e164_or_us11(from_number, to_number)
@@ -75,7 +85,7 @@ defmodule Comcent.DialUtils do
     variables =
       "[sip_h_X-Trunk-Number=#{from_number},origination_caller_id_number=#{caller_id}]"
 
-    "#{variables}sofia/internal/#{adjusted_to_number}@#{trunk_address};fs_path=#{kamailio_sip_uri}"
+    "#{variables}sofia/internal/#{adjusted_to_number}@#{trunk_address};fs_path=#{sbc_sip_uri}"
   end
 
   @doc """

--- a/server/lib/comcent/kamailio_rpc.ex
+++ b/server/lib/comcent/kamailio_rpc.ex
@@ -139,7 +139,7 @@ defmodule Comcent.KamailioRPC do
 
   # Private function to get RPC configuration
   defp get_rpc_config do
-    config = Application.get_env(:comcent, :kamailio)
+    config = Application.get_env(:comcent, :sbc)
     url = "http://#{config[:ip]}/rpc"
     api_token = config[:rpc_api_token]
     {url, api_token}

--- a/server/lib/comcent_web/controllers/internal/configuration_controller.ex
+++ b/server/lib/comcent_web/controllers/internal/configuration_controller.ex
@@ -98,29 +98,33 @@ defmodule ComcentWeb.Internal.ConfigurationController do
   end
 
   defp generate_configuration(%{"key_value" => "acl.conf"}) do
-    fs_local_network = System.get_env("FS_LOCAL_NETWORK") || ""
+    # The "private" list is referenced by the internal sofia profile's
+    # local-network-acl. ALLOWED → FS treats the destination as local and uses
+    # rtp-ip (private bind) in SDP. DENIED → FS uses ext-rtp-ip.
+    #
+    # Order matters (FreeSWITCH stops at the first matching node):
+    #   1. SBC IP — denied first so a wider FS_LOCAL_NETWORK CIDR can't
+    #      accidentally allow it.
+    #   2. FS_LOCAL_NETWORK CIDRs — explicit allows for the docker subnet (or
+    #      whatever LAN FreeSWITCH and trunk peers share).
+    #   3. Default "allow" catches everything else, so unmarked peers still
+    #      reach FS over symmetric-RTP / NAT-detected paths the same as before.
+    sbc_deny =
+      case System.get_env("SBC_IP") do
+        nil -> ""
+        "" -> ""
+        entry ->
+          cidr = if String.contains?(entry, "/"), do: entry, else: "#{entry}/32"
+          ~s(<node type="deny" cidr="#{cidr}"/>)
+      end
 
-    local_networks =
-      fs_local_network
-      |> String.split(",")
-      |> Enum.map(fn network ->
-        """
-        <node type="allow" cidr="#{network}"/>
-        """
-      end)
-      |> Enum.join("\n")
-
-    kamailio_ips = System.get_env("KAMAILIO_IPS") || ""
-
-    kamailio_ips_denied =
-      kamailio_ips
-      |> String.split(",")
-      |> Enum.map(fn ip ->
-        """
-        <node type="deny" cidr="#{ip}/32"/>
-        """
-      end)
-      |> Enum.join("\n")
+    fs_local_allows =
+      (System.get_env("FS_LOCAL_NETWORK") || "")
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.map(&~s(<node type="allow" cidr="#{&1}"/>))
+      |> Enum.join("\n              ")
 
     """
     <document type="freeswitch/xml">
@@ -129,8 +133,8 @@ defmodule ComcentWeb.Internal.ConfigurationController do
           <network-lists>
             <list name="deny" default="deny"></list>
             <list name="private" default="deny">
-              #{kamailio_ips_denied}
-              #{local_networks}
+              #{sbc_deny}
+              #{fs_local_allows}
             </list>
           </network-lists>
         </configuration>

--- a/server/test/comcent/dial_utils_test.exs
+++ b/server/test/comcent/dial_utils_test.exs
@@ -5,21 +5,21 @@ defmodule Comcent.DialUtilsTest do
   describe "create_dial_string_for_user/2" do
     test "creates a proper dial string for a user" do
       # Save original environment
-      original_kamailio_ip = System.get_env("KAMAILIO_SIP_URI")
+      original_sbc_ip = System.get_env("SBC_IP")
 
       # Set test environment
-      System.put_env("KAMAILIO_SIP_URI", "192.168.1.100")
+      System.put_env("SBC_IP", "192.168.1.100")
 
       expected =
-        "sofia/internal/test_user@test_subdomain.example.com;fs_path=192.168.1.100,[media_webrtc=true]sofia/internal/test_user@test_subdomain.example.com;fs_path=192.168.1.100"
+        "sofia/internal/test_user@test_subdomain.example.com;fs_path=sip:192.168.1.100:5065,[media_webrtc=true]sofia/internal/test_user@test_subdomain.example.com;fs_path=sip:192.168.1.100:5065"
 
       assert DialUtils.create_dial_string_for_user("test_user", "test_subdomain") == expected
 
       # Restore original environment
-      if original_kamailio_ip do
-        System.put_env("KAMAILIO_SIP_URI", original_kamailio_ip)
+      if original_sbc_ip do
+        System.put_env("SBC_IP", original_sbc_ip)
       else
-        System.delete_env("KAMAILIO_SIP_URI")
+        System.delete_env("SBC_IP")
       end
     end
   end
@@ -27,14 +27,14 @@ defmodule Comcent.DialUtilsTest do
   describe "create_dial_string_for_sip_trunk/4" do
     test "creates a proper dial string for a SIP trunk" do
       # Save original environment
-      original_kamailio_ip = System.get_env("KAMAILIO_SIP_URI")
+      original_sbc_ip = System.get_env("SBC_IP")
 
       # Set test environment
-      System.put_env("KAMAILIO_SIP_URI", "192.168.1.100")
+      System.put_env("SBC_IP", "192.168.1.100")
 
       # Test without spoofed number
       expected_no_spoof =
-        "[sip_h_X-Trunk-Number=11234567890,origination_caller_id_number=11234567890]sofia/internal/9876543210@example.com;fs_path=192.168.1.100"
+        "[sip_h_X-Trunk-Number=11234567890,origination_caller_id_number=11234567890]sofia/internal/9876543210@example.com;fs_path=sip:192.168.1.100:5065"
 
       assert DialUtils.create_dial_string_for_sip_trunk(
                "11234567890",
@@ -45,7 +45,7 @@ defmodule Comcent.DialUtilsTest do
 
       # Test with spoofed number
       expected_with_spoof =
-        "[sip_h_X-Trunk-Number=11234567890,origination_caller_id_number=5555555555]sofia/internal/9876543210@example.com;fs_path=192.168.1.100"
+        "[sip_h_X-Trunk-Number=11234567890,origination_caller_id_number=5555555555]sofia/internal/9876543210@example.com;fs_path=sip:192.168.1.100:5065"
 
       assert DialUtils.create_dial_string_for_sip_trunk(
                "11234567890",
@@ -55,10 +55,10 @@ defmodule Comcent.DialUtilsTest do
              ) == expected_with_spoof
 
       # Restore original environment
-      if original_kamailio_ip do
-        System.put_env("KAMAILIO_SIP_URI", original_kamailio_ip)
+      if original_sbc_ip do
+        System.put_env("SBC_IP", original_sbc_ip)
       else
-        System.delete_env("KAMAILIO_SIP_URI")
+        System.delete_env("SBC_IP")
       end
     end
   end


### PR DESCRIPTION
## Summary

Two themes, two commits.

**1. SBC: fix CANCEL forwarding over WebSocket to registered WebRTC agents.**
Inbound trunk → agent calls were leaving the browser ringing forever
when the trunk hung up before answer. Two bugs found in \`sbc/proxy.go\`:
- \`publicClient.WriteRequest\` with no options invoked sipgo's
  \`clientRequestBuildReq\` which stamps \`req.Laddr\` with the public
  client's bind addr (\`0.0.0.0:5060\`). \`ClientRequestConnection\`
  then looked up a pooled connection by that local addr, missed,
  tried to dial fresh, and failed on bind because the public listener
  already held the port. Pass a no-op \`ClientRequestOption\` so sipgo
  skips the build path; the inbound WS connection from REGISTER is
  reused instead.
- The hand-built CANCEL was missing two RFC 3261 §9.1 mandatory
  headers — \`CSeq\` (must mirror the INVITE SeqNo with method=CANCEL)
  and \`Max-Forwards\`. SIP.js correctly dropped the request:
  \`Missing mandatory header field : cseq\`.

Applied to both the fork-path \`cancelBranch\` and the legacy
\`cancelOutgoing\` helper.

**2. \`KAMAILIO_IP\` → \`SBC_IP\` rename + production installer + IP pinning.**
- End-to-end rename: env name, Elixir config key (\`:comcent, :kamailio\`
  → \`:comcent, :sbc\`), helper/var names, \`.env.example\`, both compose
  files, dialUtils on Elixir + TS sides. The old name was historical
  baggage from the EE Kamailio deployment; CE has been on the in-tree
  Go SBC since the fork. The \`kamailio_rpc.ex\` module/file was left
  alone — bigger rename, not load-bearing for this release.
- New \`install.sh\`: one-shot \`curl | bash\` bootstrap for fresh DO
  droplets. Verifies docker/openssl/curl, auto-detects public IP,
  generates random secrets for postgres/rabbit/internal-api/RPC/signing
  keys, prompts only for things we cannot guess (domain, LE email,
  SMTP, S3 creds, optional AI keys), downloads the deploy compose,
  writes \`.env\` (mode 600), and brings the stack up.
- \`docker-compose.deploy.yaml\`: SBC pinned to \`172.20.0.10\`, FS to
  \`172.20.0.11\`, subnet defined as \`172.20.0.0/16\` so \`SBC_IP\` /
  \`FS_LOCAL_NETWORK\` / dispatcher math is predictable across
  recreations. Dev compose pins FS to \`172.31.0.11\` for the same
  reason.
- \`acl.conf\`: \`SBC_IP\` added as DENY in the "private" list so FS
  treats SBC traffic as non-local and advertises \`ext-rtp-ip\` in
  SDP; \`FS_LOCAL_NETWORK\` CIDRs ALLOW after that;
  \`default="deny"\` preserved so unmarked peers don't get the local
  shortcut. Order matters since FS stops at the first matching node.

## Test plan
- [ ] Fresh DO droplet: \`curl -fsSL https://raw.githubusercontent.com/comcent-io/comcent-ce/main/install.sh | bash\` and verify the stack comes up, Let's Encrypt issues, and the dialer loads at the chosen domain.
- [ ] Inbound trunk call → WebRTC agent rings → trunk hangs up before answer → browser dialer stops ringing (CANCEL propagates).
- [ ] Outbound from agent → trunk picks up → either side BYE terminates the other leg.
- [ ] \`docker compose logs server\` shows no missing \`SBC_IP\`/config errors.