### PR TITLE
deploy compose: server image name is comcent-ce-server, not comcent-ce

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -100,7 +100,7 @@ services:
   # Comcent Elixir API server
   # ---------------------------------------------------------------------------
   server:
-    image: ghcr.io/comcent-io/comcent-ce:${COMCENT_VERSION:-latest}
+    image: ghcr.io/comcent-io/comcent-ce-server:${COMCENT_VERSION:-latest}
     # Fallback to local build if image not yet published to GHCR:
     build:
       context: .


### PR DESCRIPTION
Publish workflow tags the server image as `ghcr.io/comcent-io/comcent-ce-server` but `docker-compose.deploy.yaml` was pulling `ghcr.io/comcent-io/comcent-ce` (no suffix), which doesn't exist → registry returns `denied` / `not found` on a fresh pull. One-character fix.