### PR TITLE
deploy compose: run migrations on server start

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -106,6 +106,9 @@ services:
       context: .
       dockerfile: docker/Dockerfile-server
     restart: unless-stopped
+    # Run schema migrations before starting the Phoenix server. Idempotent —
+    # already-applied migrations are skipped — so it's safe on every restart.
+    command: sh -c "/app/bin/migrate && /app/bin/server start"
     env_file: .env
     environment:
       # Single source of truth — runtime.exs derives PHX_HOST,


### PR DESCRIPTION
Without this the server image boots clean but the schema is empty; every query hits `relation "x" does not exist` until `docker compose exec server /app/bin/migrate` is run by hand. Surfaced while bringing up a fresh DO droplet — daily-summary background job logged the missing-table error within seconds. Mirrors the dev compose behavior. `/app/bin/migrate` is idempotent so it's safe on every restart.