### PR TITLE
deploy: file-provider Traefik (modern Docker compatibility) + drop unused :5061

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -17,7 +17,7 @@
 # Requirements on the host:
 #   - Public DNS A record: ${COMCENT_DOMAIN} -> your droplet IP
 #   - Inbound ports open: 80, 443 (HTTP/HTTPS), 5060 UDP/TCP (SIP),
-#     5061 TCP (SIP/TLS), 19000-19100 UDP (RTP media)
+#     19000-19100 UDP (RTP media)
 #   - Docker 24+ and docker compose plugin
 #
 # All persistent data lives in named volumes (postgres_data, etc.).
@@ -28,13 +28,17 @@ services:
   # Reverse proxy — terminates TLS, routes to server/web-app, ACME for certs
   # ---------------------------------------------------------------------------
   traefik:
-    image: traefik:v3.3
+    image: traefik:v3.5
     restart: unless-stopped
+    # Why no docker provider: Docker Engine ≥25 enforces a minimum API
+    # version of 1.40, but Traefik's docker provider hard-codes the legacy
+    # 1.24 client and ignores DOCKER_API_VERSION. The daemon refuses every
+    # call → no routers, no Let's Encrypt cert. Routes are static here, so
+    # we use the file provider instead and avoid the docker socket entirely.
     command:
       - --api.dashboard=false
-      - --providers.docker=true
-      - --providers.docker.exposedbydefault=false
-      - --providers.docker.network=comcent-network
+      - --providers.file.filename=/etc/traefik/dynamic.yml
+      - --providers.file.watch=true
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
       # Force HTTPS
@@ -52,8 +56,13 @@ services:
       - '80:80'
       - '443:443'
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - traefik_letsencrypt:/letsencrypt
+    configs:
+      # Inline dynamic config — ${COMCENT_DOMAIN} is interpolated by docker
+      # compose itself when the config is written, so the Host(`…`) match
+      # ends up correct for the operator's domain without templating.
+      - source: traefik-dynamic
+        target: /etc/traefik/dynamic.yml
     networks:
       - comcent-network
 
@@ -133,13 +142,8 @@ services:
         condition: service_started
       rabbitmq:
         condition: service_started
-    labels:
-      - 'traefik.enable=true'
-      - 'traefik.http.routers.comcent-api.rule=Host(`${COMCENT_DOMAIN}`) && (PathPrefix(`/api/`) || PathPrefix(`/ws`) || PathPrefix(`/health`) || PathPrefix(`/internal-api`))'
-      - 'traefik.http.routers.comcent-api.entrypoints=websecure'
-      - 'traefik.http.routers.comcent-api.tls.certresolver=letsencrypt'
-      - 'traefik.http.routers.comcent-api.priority=100'
-      - 'traefik.http.services.comcent-api.loadbalancer.server.port=4000'
+    # Routing rules live in traefik-dynamic.yml (file provider) — see the
+    # traefik service. Docker-provider labels are not used.
     healthcheck:
       test: ['CMD', 'curl', '--fail', '--silent', 'http://127.0.0.1:4000/health']
       interval: 30s
@@ -175,19 +179,13 @@ services:
     depends_on:
       server:
         condition: service_healthy
-    labels:
-      - 'traefik.enable=true'
-      - 'traefik.http.routers.comcent-webapp.rule=Host(`${COMCENT_DOMAIN}`)'
-      - 'traefik.http.routers.comcent-webapp.entrypoints=websecure'
-      - 'traefik.http.routers.comcent-webapp.tls.certresolver=letsencrypt'
-      - 'traefik.http.routers.comcent-webapp.priority=1'
-      - 'traefik.http.services.comcent-webapp.loadbalancer.server.port=3000'
+    # Routing rules live in traefik-dynamic.yml (file provider).
     networks:
       - comcent-network
 
   # ---------------------------------------------------------------------------
   # Go SBC — SIP proxy / registrar / dispatcher (replaces Kamailio in CE)
-  # Listens on 5060 UDP+TCP for SIP signaling, 5061 TCP for SIP/TLS, and
+  # Listens on 5060 UDP+TCP for SIP signaling and
   # serves SIP-over-WSS directly on host port ${SIP_WSS_PORT:-5063}.
   # SBC terminates TLS itself using the Let's Encrypt cert Traefik already
   # issued for ${COMCENT_DOMAIN} (extracted into a shared volume by the
@@ -212,7 +210,6 @@ services:
     ports:
       - '5060:5060/udp'
       - '5060:5060/tcp'
-      - '5061:5061/tcp'
       - '${SIP_WSS_PORT:-5063}:5063/tcp'
     volumes:
       - sbc_certs:/certs:ro
@@ -320,3 +317,37 @@ volumes:
   rabbitmq_data:
   traefik_letsencrypt:
   sbc_certs:
+
+configs:
+  # Traefik dynamic config — file provider. Replaces the docker provider,
+  # which can't talk to modern Docker (its API client is hard-coded to v1.24
+  # and Docker Engine ≥25 enforces ≥1.40). ${COMCENT_DOMAIN} is interpolated
+  # by docker compose at config-write time, so the Host(...) rules match
+  # the operator's domain without templating or sed.
+  traefik-dynamic:
+    content: |
+      http:
+        routers:
+          comcent-api:
+            rule: "Host(`${COMCENT_DOMAIN}`) && (PathPrefix(`/api/`) || PathPrefix(`/ws`) || PathPrefix(`/health`) || PathPrefix(`/internal-api`))"
+            entryPoints: [websecure]
+            service: comcent-api
+            priority: 100
+            tls:
+              certResolver: letsencrypt
+          comcent-webapp:
+            rule: "Host(`${COMCENT_DOMAIN}`)"
+            entryPoints: [websecure]
+            service: comcent-webapp
+            priority: 1
+            tls:
+              certResolver: letsencrypt
+        services:
+          comcent-api:
+            loadBalancer:
+              servers:
+                - url: "http://server:4000"
+          comcent-webapp:
+            loadBalancer:
+              servers:
+                - url: "http://web-app:3000"

--- a/install.sh
+++ b/install.sh
@@ -242,7 +242,6 @@ ${B}2) Start the stack${N}
 ${B}Required inbound firewall rules${N}
    TCP    80, 443         HTTP/HTTPS (cert issuance + app)
    UDP+TCP 5060           SIP signaling
-   TCP    5061            SIP/TLS
    TCP    5063            SIP-over-WSS (browser dialer)
    UDP    19000-19100     RTP media
 


### PR DESCRIPTION
Surfaced while verifying TLS endpoints on a fresh DO droplet.

**1. Traefik docker provider was broken on modern Docker.**
Docker Engine ≥25 enforces a minimum API version of 1.40. Traefik 3.x's docker provider hard-codes the legacy v1.24 client and ignores `DOCKER_API_VERSION` env. Result on the droplet (Engine 29.4.1):
```
Failed to retrieve information of the docker client and server host
error="Error response from daemon: client version 1.24 is too old. Minimum supported API version is 1.40"
```
No routers got created, Let's Encrypt was never asked for a cert (`acme.json` was 0 bytes), `:443` served Traefik's self-signed default. Tried `DOCKER_API_VERSION=1.43` env on the container — no effect. Tried bumping to `traefik:v3.5` — same error.

Switched to the **file provider** with the routes inlined in a compose-level `configs:` block. `${COMCENT_DOMAIN}` is interpolated by docker compose at config-write time, so the `Host(`...`)` match is correct without templating or sed. The docker socket is no longer mounted into Traefik. Image bumped to `traefik:v3.5` while in the area.

**2. SBC published `:5061/tcp` but no listener was bound to it.** Probes got connection-refused; the SBC binds 5060 (UDP+TCP), 5063 (WSS), 5065 (private), 80 (HTTP+WS), 8080 (health) — there is no SIP-TLS listener implementation. Removed the dead port mapping and matching firewall line in `install.sh`.

## Verified on the droplet
```
=== https://test.comcent.io ===
  subject= /CN=test.comcent.io
  issuer= /C=US/O=Let's Encrypt/CN=R12
  notBefore=Apr 26 09:25:30 2026 GMT  notAfter=Jul 25 09:25:29 2026 GMT

=== wss://test.comcent.io:5063 ===
  subject= /CN=test.comcent.io
  issuer= /C=US/O=Let's Encrypt/CN=R12
```