### PR TITLE
httapi: emit NORMAL_CLEARING for post-bridge hangup (was USER_BUSY → BYE never sent on trunk)

### DIFF
--- a/server/lib/comcent_web/controllers/internal/httapi_controller.ex
+++ b/server/lib/comcent_web/controllers/internal/httapi_controller.ex
@@ -261,13 +261,19 @@ defmodule ComcentWeb.Internal.HttpapiController do
   end
 
   defp hangup_response do
+    # NORMAL_CLEARING (Q.850 cause 16) → BYE on an established leg, the
+    # standard "call ended" signal. The previous USER_BUSY (cause 17 →
+    # SIP 486 Busy Here) misclassified post-bridge teardown as an
+    # early-dialog decline; sofia then skipped emitting BYE on the
+    # answered trunk leg, leaving the PSTN side ringing until the caller
+    # gave up on their own.
     """
     <document type="xml/freeswitch-httapi">
       <params>
         <currentNodeId>hangup</currentNodeId>
       </params>
       <work>
-        <hangup cause='USER_BUSY' />
+        <hangup cause='NORMAL_CLEARING' />
       </work>
     </document>
     """


### PR DESCRIPTION
Inbound trunk calls weren't disconnecting the PSTN caller when the agent hung up — caller heard silence until they gave up and dropped themselves.

Wire trace from a fresh DO droplet (port 5060/5065 between SBC and FS):

```
twilio → INVITE → SBC → FS         (call answered, audio flows)
agent  → BYE   → SBC → FS         (agent leg torn down)
...silence on 5060/5065...
twilio → BYE   → SBC → FS         (5–22s later — caller gave up)
```

Cause: `hangup_response/0` always returns `<hangup cause='USER_BUSY'/>`. USER_BUSY (Q.850 cause 17 → SIP 486 Busy Here) is an early-dialog response code; mod_httapi on an answered leg seems to route this through the decline path and skips the BYE that sofia would otherwise emit. So the trunk leg never receives a final disconnect and the PSTN call stays alive.

Switched to NORMAL_CLEARING (Q.850 cause 16) — the standard end-of-call mapping. Sofia then emits BYE on the answered trunk leg as soon as the dialplan returns and twilio drops immediately.