### PR TITLE
httapi: route hangup through dialplan engine so sofia actually emits BYE

### DIFF
--- a/server/lib/comcent_web/controllers/internal/httapi_controller.ex
+++ b/server/lib/comcent_web/controllers/internal/httapi_controller.ex
@@ -261,19 +261,21 @@ defmodule ComcentWeb.Internal.HttpapiController do
   end
 
   defp hangup_response do
-    # NORMAL_CLEARING (Q.850 cause 16) → BYE on an established leg, the
-    # standard "call ended" signal. The previous USER_BUSY (cause 17 →
-    # SIP 486 Busy Here) misclassified post-bridge teardown as an
-    # early-dialog decline; sofia then skipped emitting BYE on the
-    # answered trunk leg, leaving the PSTN side ringing until the caller
-    # gave up on their own.
+    # Use the dialplan `hangup` application via <execute>, NOT the bare
+    # <hangup> action. mod_httapi's <hangup> moves the channel straight
+    # from CS_EXECUTE to CS_DESTROY, skipping the CS_HANGUP state where
+    # sofia normally emits the SIP BYE. The PSTN side then sat with the
+    # call open until the caller gave up on their own (verified on a
+    # fresh DO droplet — twilio sent its own BYE 60+s after the agent
+    # hung up). Routing through the dialplan engine takes the standard
+    # state path so sofia sends BYE immediately.
     """
     <document type="xml/freeswitch-httapi">
       <params>
         <currentNodeId>hangup</currentNodeId>
       </params>
       <work>
-        <hangup cause='NORMAL_CLEARING' />
+        <execute application="hangup" data="NORMAL_CLEARING" />
       </work>
     </document>
     """


### PR DESCRIPTION
Even after switching to NORMAL_CLEARING, the trunk leg still wasn't getting BYE. State-machine trace from the droplet (uuid `26da93fe` was the trunk leg in the most recent test):

```
05:21:11.828  CS_NEW → answered (200 OK out)
05:21:11.869  bridge() runs, agent answers, audio flows
05:21:21.708  mod_httapi.c:888 Hangup [CS_EXECUTE] [NORMAL_CLEARING]
05:21:21.728  Session Ended
05:21:21.728  Close Channel [CS_DESTROY]                ← jumped past CS_HANGUP
```

Channel went CS_EXECUTE → CS_DESTROY in 20ms, completely skipping the CS_HANGUP transition where sofia emits BYE. So mod_httapi's bare `<hangup>` tag does some kind of internal teardown that bypasses the SIP layer.

Switching to `<execute application="hangup" data="NORMAL_CLEARING"/>` routes through the standard dialplan engine, which takes the CS_HANGUP path → sofia sends BYE → twilio drops the call immediately.