### PR TITLE
deploy: pass PRIVATE_IP / PUBLIC_IP to SBC so Record-Route is routable from FS

### DIFF
--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -207,6 +207,14 @@ services:
       WSS_CERT_PATH: /certs/certs/${COMCENT_DOMAIN}.crt
       WSS_KEY_PATH: /certs/private/${COMCENT_DOMAIN}.key
       WSS_PORT: '5063'
+      # SBC's docker-network IP (matches the pinned ipv4_address below).
+      # Used in the Record-Route header SBC stamps on every forwarded
+      # request — must be reachable from FS, not 127.0.0.1 (the default).
+      PRIVATE_IP: ${SBC_IP:-172.20.0.10}
+      # Public IP that the SBC advertises in Record-Route / Via on its
+      # public listener. Without this, default 127.0.0.1 leaks into
+      # outbound headers toward the PSTN trunk.
+      PUBLIC_IP: ${PUBLIC_IP}
     ports:
       - '5060:5060/udp'
       - '5060:5060/tcp'


### PR DESCRIPTION
Inbound trunk calls weren't disconnecting the PSTN caller when the agent hung up. Three speculative fixes earlier (#7, #8, #9) didn't address it.

**Real cause** — wire trace from the droplet, BYE FS tried to send on the trunk leg:
```
BYE sip:+16174017687@... SIP/2.0
Route: <sip:127.0.0.1:5065;lr>     <- first hop = LOOPBACK
Route: <sip:168.144.94.195:5060;lr>
Route: <sip:54.172.60.2;lr>
```

FS strict-routes to the first Route header → `127.0.0.1:5065` → loopback inside the FS container → no listener → BYE dropped, twilio never learns the call ended.

The `127.0.0.1:5065` was stamped by SBC as its Record-Route on the original INVITE. `sbc/config.go` defaults `PRIVATE_IP` and `PUBLIC_IP` to `127.0.0.1` (sane for solo dev, useless in containers), and the deploy compose wasn't overriding them.

Added both vars to the SBC service in deploy compose. `install.sh` already writes `PUBLIC_IP` (auto-detected) and `SBC_IP` (pinned to 172.20.0.10) into `.env`, so the interpolation works without any installer change.

## Verified on the droplet
All four trunk-call termination paths now disconnect both legs cleanly:
- Agent hangs up before answering
- Agent hangs up after answering
- Customer hangs up before answering
- Customer hangs up after answering