### PR TITLE
SBC: keep trunk FQDN in outbound R-URI (Twilio rejects bare edge IP)

### DIFF
--- a/sbc/proxy.go
+++ b/sbc/proxy.go
@@ -566,20 +566,21 @@ func (p *Proxy) handleInviteFromFSToTrunk(req *sip.Request, tx sip.ServerTransac
 		return
 	}
 
+	// Build R-URI from the trunk's configured contact (typically an FQDN
+	// like "<trunk>.pstn.twilio.com"). Carriers like Twilio use the R-URI
+	// host to identify which customer trunk the call belongs to and reject
+	// with 403 if it sees a bare edge IP they don't recognize. Resolve to
+	// IP only for the network destination so the packet actually routes.
+	contactHost, contactPort := splitHostPort(trunk.OutboundContact, 5060)
 	dest := resolveHost(trunk.OutboundContact)
 	callID := req.CallID().Value()
-	slog.Info("Proxy: FS→trunk", "number", trunkHeader.Value(), "dest", dest)
+	slog.Info("Proxy: FS→trunk", "number", trunkHeader.Value(),
+		"r-uri-host", contactHost, "dest", dest)
 
 	// 100 Trying
 	tx.Respond(sip.NewResponseFromRequest(req, 100, "Trying", nil))
 
-	// Build forwarded INVITE
-	parts := strings.SplitN(dest, ":", 2)
-	port := 5060
-	if len(parts) == 2 {
-		port, _ = strconv.Atoi(parts[1])
-	}
-	trunkURI := sip.Uri{User: toUser, Host: parts[0], Port: port}
+	trunkURI := sip.Uri{User: toUser, Host: contactHost, Port: contactPort}
 
 	fwdReq, ok := p.buildForwardRequestWithURI(req, trunkURI)
 	if !ok {
@@ -1520,6 +1521,21 @@ func resolveHost(hostPort string) string {
 		return hostPort
 	}
 	return addrs[0] + ":" + port
+}
+
+// splitHostPort takes "host" or "host:port" and returns (host, port). Unlike
+// net.SplitHostPort it tolerates a bare host (no colon) and returns the
+// supplied default port in that case.
+func splitHostPort(hostPort string, defaultPort int) (string, int) {
+	parts := strings.SplitN(hostPort, ":", 2)
+	if len(parts) == 1 {
+		return parts[0], defaultPort
+	}
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return parts[0], defaultPort
+	}
+	return parts[0], port
 }
 
 func parsePort(addr string) int {


### PR DESCRIPTION
Outbound trunk calls were rejected by Twilio with bare `403 Forbidden`. Wire trace from the droplet:

```
FS  → SBC    : INVITE sip:+16174017687@comcentstaging.pstn.twilio.com SIP/2.0
SBC → twilio : INVITE sip:+16174017687@54.172.60.0:5060 SIP/2.0           ← IP
```

`handleInviteFromFSToTrunk` was running `resolveHost(trunk.OutboundContact)` and using the resulting IP as the R-URI host. Twilio identifies which customer trunk a call belongs to by the R-URI host (or `To:` domain) — when it sees a bare edge IP it doesn't recognise, it `403`s even if the source IP is on the trunk's IP ACL.

Split the two concerns: keep the configured FQDN as the R-URI host so Twilio can identify the trunk, resolve to IP only for `SetDestination` so the packet still routes correctly via UDP.

Verified on the DO droplet by hot-swapping the binary before committing. All four agent-→-customer termination scenarios now work end to end:
- customer hangs up before answering (goes to voicemail)
- customer hangs up after answering
- agent hangs up before customer picks up
- agent hangs up after customer picks up