### PR TITLE
auth: gate CE signup with first-run setup token + invite-only

### DIFF
--- a/packages/web-app/src/routes/login/+page.server.ts
+++ b/packages/web-app/src/routes/login/+page.server.ts
@@ -5,6 +5,7 @@ import { getInternalJson, postInternalJson } from '$lib/server/api';
 
 type AuthConfig = {
   passwordEnabled: boolean;
+  bootstrapMode: boolean;
   oauthProviders: Array<{ id: string; label: string; type: string }>;
 };
 
@@ -31,10 +32,14 @@ export const load: ServerLoad = async ({ cookies, fetch }) => {
 
   const authConfigResult = await getInternalJson<AuthConfig>('/api/v2/auth/config', fetch);
 
+  if (authConfigResult.ok && authConfigResult.data.bootstrapMode) {
+    throw redirect(303, '/setup');
+  }
+
   return {
     authConfig: authConfigResult.ok
       ? authConfigResult.data
-      : { passwordEnabled: true, oauthProviders: [] },
+      : { passwordEnabled: true, bootstrapMode: false, oauthProviders: [] },
   };
 };
 

--- a/packages/web-app/src/routes/setup/+page.server.ts
+++ b/packages/web-app/src/routes/setup/+page.server.ts
@@ -1,0 +1,68 @@
+import { fail, redirect } from '@sveltejs/kit';
+import type { Actions, ServerLoad } from './$types';
+import { getInternalJson, postInternalJson } from '$lib/server/api';
+
+type AuthConfig = {
+  passwordEnabled: boolean;
+  bootstrapMode: boolean;
+  oauthProviders: Array<{ id: string; label: string; type: string }>;
+};
+
+type ClaimResponse = {
+  token?: string;
+  user?: {
+    id: string;
+    email: string;
+    name: string;
+    authProvider: string;
+  };
+};
+
+export const load: ServerLoad = async ({ fetch }) => {
+  const result = await getInternalJson<AuthConfig>('/api/v2/auth/config', fetch);
+
+  if (!result.ok || !result.data.bootstrapMode) {
+    throw redirect(303, '/login');
+  }
+
+  return {
+    passwordEnabled: result.data.passwordEnabled,
+  };
+};
+
+export const actions: Actions = {
+  claim: async ({ request, cookies, fetch }) => {
+    const formData = await request.formData();
+    const payload = {
+      name: String(formData.get('name') || ''),
+      email: String(formData.get('email') || ''),
+      password: String(formData.get('password') || ''),
+      org_name: String(formData.get('orgName') || ''),
+      subdomain: String(formData.get('subdomain') || ''),
+      sip_username: String(formData.get('sipUsername') || ''),
+      token: String(formData.get('token') || ''),
+    };
+
+    const result = await postInternalJson<ClaimResponse>(
+      '/api/v2/auth/claim-setup',
+      payload,
+      fetch,
+    );
+
+    if (!result.ok) {
+      return fail(result.status || 400, {
+        error: result.error,
+        values: {
+          name: payload.name,
+          email: payload.email,
+          orgName: payload.org_name,
+          subdomain: payload.subdomain,
+          sipUsername: payload.sip_username,
+        },
+      });
+    }
+
+    cookies.set('idToken', result.data.token!, { path: '/', httpOnly: false });
+    throw redirect(303, '/app');
+  },
+};

--- a/packages/web-app/src/routes/setup/+page.svelte
+++ b/packages/web-app/src/routes/setup/+page.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+  export let form;
+  $: values = form?.values ?? {};
+</script>
+
+<section class="min-h-screen bg-gray-50 dark:bg-gray-900">
+  <div class="mx-auto flex min-h-screen max-w-5xl items-center px-6 py-10">
+    <div class="grid w-full gap-8 md:grid-cols-[1.2fr_0.8fr]">
+      <div class="rounded-3xl bg-slate-900 p-10 text-white shadow-2xl">
+        <p class="text-sm uppercase tracking-[0.3em] text-cyan-300">Comcent</p>
+        <h1 class="mt-4 text-4xl font-semibold leading-tight">Claim this instance.</h1>
+        <p class="mt-4 max-w-xl text-sm text-slate-300">
+          This Comcent install has no super-admin yet. The first person to enter the setup token
+          (printed in the server logs on startup) will become the super-admin and create the
+          initial organization. After that, signup is invite-only.
+        </p>
+        <p class="mt-4 max-w-xl text-xs text-slate-400">
+          Lost the token? On the server host, run
+          <code class="rounded bg-slate-800 px-1.5 py-0.5">mix comcent.reset_setup_token</code>.
+        </p>
+      </div>
+
+      <div
+        class="rounded-3xl border border-slate-200 bg-white p-8 shadow-xl dark:border-slate-700 dark:bg-slate-800"
+      >
+        <form method="POST" action="?/claim" class="space-y-4">
+          <div>
+            <label
+              for="setup-token"
+              class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Setup token
+            </label>
+            <input
+              id="setup-token"
+              name="token"
+              type="text"
+              required
+              autocomplete="off"
+              class="block w-full rounded-xl border border-slate-300 px-4 py-3 font-mono text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+            />
+          </div>
+
+          <div>
+            <label
+              for="setup-name"
+              class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Your full name
+            </label>
+            <input
+              id="setup-name"
+              name="name"
+              type="text"
+              required
+              value={values.name ?? ''}
+              class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+            />
+          </div>
+
+          <div>
+            <label
+              for="setup-email"
+              class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Email address
+            </label>
+            <input
+              id="setup-email"
+              name="email"
+              type="email"
+              required
+              value={values.email ?? ''}
+              class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+            />
+          </div>
+
+          <div>
+            <label
+              for="setup-password"
+              class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+            >
+              Password (8+ characters)
+            </label>
+            <input
+              id="setup-password"
+              name="password"
+              type="password"
+              required
+              minlength="8"
+              class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+            />
+          </div>
+
+          <div class="border-t border-slate-200 pt-4 dark:border-slate-700">
+            <p class="mb-3 text-sm font-medium text-slate-600 dark:text-slate-300">
+              Organization details
+            </p>
+
+            <div class="space-y-4">
+              <div>
+                <label
+                  for="setup-org-name"
+                  class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                >
+                  Organization name
+                </label>
+                <input
+                  id="setup-org-name"
+                  name="orgName"
+                  type="text"
+                  required
+                  value={values.orgName ?? ''}
+                  class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label
+                  for="setup-subdomain"
+                  class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                >
+                  Subdomain (used in URLs and SIP addresses)
+                </label>
+                <input
+                  id="setup-subdomain"
+                  name="subdomain"
+                  type="text"
+                  required
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  value={values.subdomain ?? ''}
+                  class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+                />
+              </div>
+
+              <div>
+                <label
+                  for="setup-sip-username"
+                  class="mb-2 block text-sm font-medium text-slate-700 dark:text-slate-200"
+                >
+                  Your SIP username inside the org
+                </label>
+                <input
+                  id="setup-sip-username"
+                  name="sipUsername"
+                  type="text"
+                  required
+                  value={values.sipUsername ?? ''}
+                  class="block w-full rounded-xl border border-slate-300 px-4 py-3 text-sm focus:border-cyan-500 focus:outline-none dark:border-slate-600 dark:bg-slate-900 dark:text-white"
+                />
+              </div>
+            </div>
+          </div>
+
+          {#if form?.error}
+            <p class="text-sm text-red-600 dark:text-red-400">{form.error}</p>
+          {/if}
+
+          <button
+            type="submit"
+            class="w-full rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-700 dark:bg-cyan-500 dark:text-slate-950"
+          >
+            Claim instance
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</section>

--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -263,9 +263,19 @@ oidc_providers =
   System.get_env("AUTH_OIDC_PROVIDERS_JSON", "{}")
   |> Jason.decode!()
 
+# Comma-separated list of email domains that may self-register (e.g.
+# "acme.com,acme.co.uk"). Empty by default → invite-only.
+allowed_signup_domains =
+  System.get_env("ALLOWED_SIGNUP_DOMAIN", "")
+  |> String.split(",")
+  |> Enum.map(&String.trim/1)
+  |> Enum.map(&String.downcase/1)
+  |> Enum.reject(&(&1 == ""))
+
 config :comcent, :auth,
   password_enabled: password_enabled,
-  oidc_providers: oidc_providers
+  oidc_providers: oidc_providers,
+  allowed_signup_domains: allowed_signup_domains
 
 # Email Configuration
 smtp_url =

--- a/server/lib/comcent/application.ex
+++ b/server/lib/comcent/application.ex
@@ -49,6 +49,11 @@ defmodule Comcent.Application do
     end)
 
     Task.start(fn ->
+      Process.sleep(3000)
+      Comcent.InstanceSetup.ensure_token!()
+    end)
+
+    Task.start(fn ->
       # Give the database connection time to fully establish
       Process.sleep(3000)
       Comcent.Queue.AgentSession.start_all_active_sessions()

--- a/server/lib/comcent/auth/provider_config.ex
+++ b/server/lib/comcent/auth/provider_config.ex
@@ -18,6 +18,30 @@ defmodule Comcent.Auth.ProviderConfig do
     |> Enum.sort_by(& &1.id)
   end
 
+  def allowed_signup_domains do
+    auth_config()
+    |> Keyword.get(:allowed_signup_domains, [])
+  end
+
+  def signup_open_to_domain?(email) when is_binary(email) do
+    case allowed_signup_domains() do
+      [] ->
+        false
+
+      domains ->
+        domain =
+          email
+          |> String.downcase()
+          |> String.trim()
+          |> String.split("@", parts: 2)
+          |> List.last()
+
+        is_binary(domain) and domain != "" and domain in domains
+    end
+  end
+
+  def signup_open_to_domain?(_), do: false
+
   def fetch_provider(provider_id) when is_binary(provider_id) do
     case auth_config()[:oidc_providers][provider_id] do
       nil -> {:error, :provider_not_found}
@@ -26,7 +50,11 @@ defmodule Comcent.Auth.ProviderConfig do
   end
 
   defp auth_config do
-    Application.get_env(:comcent, :auth, password_enabled: true, oidc_providers: %{})
+    Application.get_env(:comcent, :auth,
+      password_enabled: true,
+      oidc_providers: %{},
+      allowed_signup_domains: []
+    )
   end
 
   defp normalize_provider(provider_id, config) do

--- a/server/lib/comcent/instance_setup.ex
+++ b/server/lib/comcent/instance_setup.ex
@@ -1,0 +1,237 @@
+defmodule Comcent.InstanceSetup do
+  @moduledoc """
+  First-run instance bootstrap. On a fresh CE install, the operator needs a
+  way to claim the instance as super-admin without exposing open signup to
+  the public internet. This module generates a one-time setup token on first
+  boot, prints it to the server logs, and lets the operator consume it by
+  POSTing to `/api/v2/auth/claim-setup`. Once claimed, the install is locked
+  to invite-only (with an optional domain allowlist) — see
+  `Comcent.Auth.ProviderConfig.allowed_signup_domains/0`.
+  """
+
+  require Logger
+  import Ecto.Query
+
+  alias Comcent.Auth.Password
+  alias Comcent.Repo
+  alias Comcent.Schemas.{InstanceSetup, Org, OrgMember, User}
+  alias Ecto.Multi
+
+  @singleton_id 1
+  @trial_max_members 10
+
+  @doc """
+  Returns true when no super-admin exists yet — i.e. the instance still
+  needs to be claimed.
+  """
+  def bootstrap_mode? do
+    not Repo.exists?(from(u in User, where: u.is_super_admin == true))
+  end
+
+  @doc """
+  Called from `Comcent.Application.start/2` after the Repo is up. If the
+  instance still needs a super-admin, ensure a setup-token row exists and
+  print the claim banner to the logs.
+  """
+  def ensure_token! do
+    if bootstrap_mode?() do
+      row = ensure_row!()
+      log_banner(row.token)
+    else
+      :ok
+    end
+  end
+
+  @doc """
+  Atomically claim the instance. Creates the super-admin user, the org, and
+  the OrgMember ADMIN row, then marks the token consumed.
+  """
+  def claim(name, email, password, %{
+        org_name: org_name,
+        subdomain: subdomain,
+        sip_username: sip_username,
+        token: token
+      }) do
+    with :ok <- validate_inputs(name, email, password, org_name, subdomain, sip_username, token),
+         {:ok, %{user: user}} <- run_claim_transaction(name, email, password, org_name, subdomain, sip_username, token) do
+      {:ok, user}
+    else
+      {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, format_changeset_error(changeset)}
+
+      {:error, reason} when is_atom(reason) or is_binary(reason) ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Regenerate the token. When `force?` is true, also clears `consumed_at`
+  and `consumed_by_user_id`. Used by `mix comcent.reset_setup_token`.
+  """
+  def regenerate_token!(force? \\ false) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    new_token = generate_token()
+
+    row = ensure_row!()
+
+    cond do
+      not is_nil(row.consumed_at) and not force? ->
+        {:error, :already_consumed}
+
+      true ->
+        attrs = %{
+          token: new_token,
+          generated_at: now,
+          consumed_at: if(force?, do: nil, else: row.consumed_at),
+          consumed_by_user_id: if(force?, do: nil, else: row.consumed_by_user_id)
+        }
+
+        row
+        |> InstanceSetup.changeset(attrs)
+        |> Repo.update!()
+
+        {:ok, new_token}
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+
+  defp ensure_row! do
+    case Repo.get(InstanceSetup, @singleton_id) do
+      nil ->
+        %InstanceSetup{}
+        |> InstanceSetup.changeset(%{
+          id: @singleton_id,
+          token: generate_token(),
+          generated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+        |> Repo.insert!()
+
+      %InstanceSetup{token: nil} = row ->
+        row
+        |> InstanceSetup.changeset(%{
+          token: generate_token(),
+          generated_at: DateTime.utc_now() |> DateTime.truncate(:second)
+        })
+        |> Repo.update!()
+
+      row ->
+        row
+    end
+  end
+
+  defp generate_token do
+    :crypto.strong_rand_bytes(24) |> Base.url_encode64(padding: false)
+  end
+
+  defp log_banner(token) do
+    public_url = Application.get_env(:comcent, :public_root_url, "<your public URL>")
+
+    Logger.info("""
+
+    ╔══════════════════════════════════════════════════════════════════════╗
+    ║  COMCENT FIRST-RUN SETUP                                             ║
+    ║                                                                      ║
+    ║  This instance has no super-admin yet. Claim it by visiting:         ║
+    ║    #{String.pad_trailing(public_url <> "/setup", 66)}║
+    ║                                                                      ║
+    ║  Setup token (one-time use — do NOT share):                          ║
+    ║    #{String.pad_trailing(token, 66)}║
+    ║                                                                      ║
+    ║  This banner will reappear on every restart until claimed. Lost the  ║
+    ║  token? Run:  mix comcent.reset_setup_token  (or --force after       ║
+    ║  consumption).                                                       ║
+    ╚══════════════════════════════════════════════════════════════════════╝
+    """)
+  end
+
+  defp validate_inputs(name, email, password, org_name, subdomain, sip_username, token) do
+    cond do
+      blank?(name) -> {:error, "Name is required"}
+      blank?(email) -> {:error, "Email is required"}
+      blank?(password) or String.length(password) < 8 ->
+        {:error, "Password must be at least 8 characters"}
+      blank?(org_name) -> {:error, "Organization name is required"}
+      blank?(subdomain) -> {:error, "Subdomain is required"}
+      blank?(sip_username) -> {:error, "SIP username is required"}
+      blank?(token) -> {:error, "Setup token is required"}
+      true -> :ok
+    end
+  end
+
+  defp run_claim_transaction(name, email, password, org_name, subdomain, sip_username, token) do
+    user_id = Ecto.UUID.generate()
+    org_id = Ecto.UUID.generate()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    normalized_email = email |> String.trim() |> String.downcase()
+
+    Multi.new()
+    |> Multi.run(:setup_row, fn repo, _ ->
+      case repo.get(InstanceSetup, @singleton_id) do
+        nil -> {:error, "Setup token is not configured. Restart the server."}
+        %InstanceSetup{consumed_at: %DateTime{}} -> {:error, "This instance has already been claimed."}
+        %InstanceSetup{token: stored} = row when stored == token -> {:ok, row}
+        _ -> {:error, "Invalid setup token."}
+      end
+    end)
+    |> Multi.run(:no_super_admin, fn repo, _ ->
+      if repo.exists?(from(u in User, where: u.is_super_admin == true)) do
+        {:error, "This instance has already been claimed."}
+      else
+        {:ok, :ok}
+      end
+    end)
+    |> Multi.run(:email_unique, fn repo, _ ->
+      if repo.exists?(from(u in User, where: u.email == ^normalized_email)) do
+        {:error, "Email already exists"}
+      else
+        {:ok, :ok}
+      end
+    end)
+    |> Multi.insert(:user,
+      User.changeset(%User{id: user_id}, %{
+        name: String.trim(name),
+        email: normalized_email,
+        password_hash: Password.hash(password),
+        is_email_verified: true,
+        is_super_admin: true
+      })
+    )
+    |> Multi.insert(:org,
+      Org.changeset(%Org{id: org_id}, %{
+        name: String.trim(org_name),
+        subdomain: String.trim(subdomain),
+        use_custom_domain: false,
+        assign_ext_automatically: false,
+        max_members: @trial_max_members
+      })
+    )
+    |> Multi.insert(:member,
+      OrgMember.changeset(%OrgMember{}, %{
+        user_id: user_id,
+        org_id: org_id,
+        role: "ADMIN",
+        username: String.trim(sip_username),
+        sip_password: :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
+      })
+    )
+    |> Multi.update(:consume_token, fn %{setup_row: row, user: user} ->
+      InstanceSetup.changeset(row, %{
+        consumed_at: now,
+        consumed_by_user_id: user.id
+      })
+    end)
+    |> Repo.transaction()
+  end
+
+  defp blank?(nil), do: true
+  defp blank?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank?(_), do: true
+
+  defp format_changeset_error(changeset) do
+    case changeset.errors do
+      [{field, {message, _opts}} | _rest] -> "#{field} #{message}"
+      _ -> "Setup failed"
+    end
+  end
+end

--- a/server/lib/comcent/schemas/instance_setup.ex
+++ b/server/lib/comcent/schemas/instance_setup.ex
@@ -1,0 +1,20 @@
+defmodule Comcent.Schemas.InstanceSetup do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :integer, autogenerate: false}
+  schema "instance_setup" do
+    field(:token, :string)
+    field(:generated_at, :utc_datetime)
+    field(:consumed_at, :utc_datetime)
+    field(:consumed_by_user_id, :string)
+
+    timestamps(inserted_at: :created_at, updated_at: :updated_at)
+  end
+
+  def changeset(row, attrs) do
+    row
+    |> cast(attrs, [:id, :token, :generated_at, :consumed_at, :consumed_by_user_id])
+    |> validate_required([:id])
+  end
+end

--- a/server/lib/comcent_web/controllers/auth_controller.ex
+++ b/server/lib/comcent_web/controllers/auth_controller.ex
@@ -7,8 +7,9 @@ defmodule ComcentWeb.AuthController do
   alias Comcent.Auth.Password
   alias Comcent.Auth.ProviderConfig
   alias Comcent.Emails
+  alias Comcent.InstanceSetup
   alias Comcent.Repo
-  alias Comcent.Schemas.{User, UserIdentity}
+  alias Comcent.Schemas.{OrgInvite, User, UserIdentity}
 
   @verification_resend_cooldown_seconds 60
   @verification_resend_limit_per_day 3
@@ -17,21 +18,69 @@ defmodule ComcentWeb.AuthController do
   def config(conn, _params) do
     json(conn, %{
       password_enabled: ProviderConfig.password_enabled?(),
-      oauth_providers: ProviderConfig.public_provider_configs()
+      oauth_providers: ProviderConfig.public_provider_configs(),
+      bootstrap_mode: InstanceSetup.bootstrap_mode?()
     })
   end
 
   def register(conn, params) do
-    if ProviderConfig.password_enabled?() do
-      with :ok <- validate_registration(params),
-           {:ok, _user} <- create_password_user(params) do
-        json(conn, %{message: "Check your email to verify your account before signing in."})
-      else
-        {:error, message} ->
-          conn |> put_status(:bad_request) |> json(%{error: message})
-      end
-    else
-      conn |> put_status(:not_found) |> json(%{error: "Password authentication is disabled"})
+    cond do
+      not ProviderConfig.password_enabled?() ->
+        conn |> put_status(:not_found) |> json(%{error: "Password authentication is disabled"})
+
+      InstanceSetup.bootstrap_mode?() ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{
+          error:
+            "This instance has not been claimed yet. Visit /setup with the server's setup token."
+        })
+
+      true ->
+        with :ok <- validate_registration(params),
+             :ok <- validate_signup_allowed(params["email"]),
+             {:ok, _user} <- create_password_user(params) do
+          json(conn, %{message: "Check your email to verify your account before signing in."})
+        else
+          {:error, :not_allowed} ->
+            conn
+            |> put_status(:forbidden)
+            |> json(%{
+              error: signup_not_allowed_message()
+            })
+
+          {:error, message} ->
+            conn |> put_status(:bad_request) |> json(%{error: message})
+        end
+    end
+  end
+
+  def claim_setup(conn, params) do
+    cond do
+      not ProviderConfig.password_enabled?() ->
+        conn |> put_status(:not_found) |> json(%{error: "Password authentication is disabled"})
+
+      not InstanceSetup.bootstrap_mode?() ->
+        conn
+        |> put_status(:forbidden)
+        |> json(%{error: "This instance has already been claimed."})
+
+      true ->
+        attrs = %{
+          org_name: params["org_name"],
+          subdomain: params["subdomain"],
+          sip_username: params["sip_username"],
+          token: params["token"]
+        }
+
+        case InstanceSetup.claim(params["name"], params["email"], params["password"], attrs) do
+          {:ok, user} ->
+            session_token = Auth.sign_session_token(user, "password")
+            json(conn, %{token: session_token, user: session_user(user, "password")})
+
+          {:error, message} ->
+            conn |> put_status(:bad_request) |> json(%{error: message})
+        end
     end
   end
 
@@ -181,6 +230,34 @@ defmodule ComcentWeb.AuthController do
 
   def resend_verification(conn, _params) do
     conn |> put_status(:bad_request) |> json(%{error: "Email is required"})
+  end
+
+  defp validate_signup_allowed(email) do
+    normalized = normalize_email(email)
+
+    cond do
+      ProviderConfig.signup_open_to_domain?(normalized) ->
+        :ok
+
+      Repo.exists?(
+        from(i in OrgInvite, where: i.email == ^normalized and i.status == "PENDING")
+      ) ->
+        :ok
+
+      true ->
+        {:error, :not_allowed}
+    end
+  end
+
+  defp signup_not_allowed_message do
+    case ProviderConfig.allowed_signup_domains() do
+      [] ->
+        "Signup is invite-only on this instance. Ask your admin to send you an invite."
+
+      domains ->
+        "Signup is invite-only on this instance. " <>
+          "Self-signup is only allowed for emails at: #{Enum.join(domains, ", ")}."
+    end
   end
 
   defp validate_registration(params) do
@@ -372,11 +449,24 @@ defmodule ComcentWeb.AuthController do
             updated_user
 
           nil ->
+            existing = Repo.get_by(User, email: normalize_email(oauth_user.email))
+
             user =
-              Repo.get_by(User, email: normalize_email(oauth_user.email))
-              |> case do
-                nil -> insert_oauth_user(oauth_user)
-                %User{} = existing_user -> update_user_from_oauth(existing_user, oauth_user)
+              case existing do
+                %User{} = existing_user ->
+                  update_user_from_oauth(existing_user, oauth_user)
+
+                nil ->
+                  cond do
+                    InstanceSetup.bootstrap_mode?() ->
+                      Repo.rollback(:bootstrap_mode)
+
+                    validate_signup_allowed(oauth_user.email) != :ok ->
+                      Repo.rollback(:signup_not_allowed)
+
+                    true ->
+                      insert_oauth_user(oauth_user)
+                  end
               end
 
             insert_identity(user, oauth_user)
@@ -385,6 +475,8 @@ defmodule ComcentWeb.AuthController do
       end)
       |> case do
         {:ok, user} -> {:ok, user}
+        {:error, :bootstrap_mode} -> {:error, "This instance has not been claimed yet. Visit /setup first."}
+        {:error, :signup_not_allowed} -> {:error, signup_not_allowed_message()}
         {:error, reason} -> {:error, reason}
       end
     end

--- a/server/lib/comcent_web/controllers/user_controller.ex
+++ b/server/lib/comcent_web/controllers/user_controller.ex
@@ -124,12 +124,18 @@ defmodule ComcentWeb.UserController do
   def create_org(conn, params) do
     current_user = conn.assigns[:current_user]
 
-    with :ok <- validate_create_org_params(params),
-         {:ok, org} <- insert_org(current_user, params) do
-      json(conn, %{success: true, org: %{id: org.id, subdomain: org.subdomain}})
+    if current_user.is_super_admin do
+      with :ok <- validate_create_org_params(params),
+           {:ok, org} <- insert_org(current_user, params) do
+        json(conn, %{success: true, org: %{id: org.id, subdomain: org.subdomain}})
+      else
+        {:error, message} ->
+          conn |> put_status(:bad_request) |> json(%{error: message})
+      end
     else
-      {:error, message} ->
-        conn |> put_status(:bad_request) |> json(%{error: message})
+      conn
+      |> put_status(:forbidden)
+      |> json(%{error: "Only the instance super-admin can create orgs on this install."})
     end
   end
 

--- a/server/lib/comcent_web/router.ex
+++ b/server/lib/comcent_web/router.ex
@@ -170,6 +170,7 @@ defmodule ComcentWeb.Router do
     get("/auth/config", AuthController, :config)
     post("/auth/login", AuthController, :login)
     post("/auth/register", AuthController, :register)
+    post("/auth/claim-setup", AuthController, :claim_setup)
     post("/auth/verify-email", AuthController, :verify_email)
     post("/auth/resend-verification", AuthController, :resend_verification)
     get("/auth/oauth/:provider/start", AuthController, :oauth_start)

--- a/server/lib/mix/tasks/comcent.reset_setup_token.ex
+++ b/server/lib/mix/tasks/comcent.reset_setup_token.ex
@@ -1,0 +1,46 @@
+defmodule Mix.Tasks.Comcent.ResetSetupToken do
+  @moduledoc """
+  Regenerate the first-run setup token.
+
+      mix comcent.reset_setup_token           # only if token has not been consumed
+      mix comcent.reset_setup_token --force   # also clears consumed_at / consumed_by_user_id
+
+  In a release (no Mix available), call equivalently:
+
+      bin/comcent eval 'Comcent.InstanceSetup.regenerate_token!(true)'
+  """
+
+  use Mix.Task
+
+  @shortdoc "Regenerate the first-run setup token"
+
+  @impl Mix.Task
+  def run(args) do
+    force? = "--force" in args
+
+    Mix.Task.run("app.start")
+
+    case Comcent.InstanceSetup.regenerate_token!(force?) do
+      {:ok, token} ->
+        IO.puts("""
+
+        New setup token:
+          #{token}
+
+        Visit /setup on this instance to claim the super-admin account.
+        """)
+
+      {:error, :already_consumed} ->
+        IO.puts(:stderr, """
+        Refusing to regenerate: this instance has already been claimed.
+
+        If you really want to allow a new super-admin to claim it (this
+        does NOT revoke the existing super-admin), re-run with --force:
+
+          mix comcent.reset_setup_token --force
+        """)
+
+        exit({:shutdown, 1})
+    end
+  end
+end

--- a/server/priv/repo/migrations/20260523000000_add_instance_setup_and_promote_first_admin.exs
+++ b/server/priv/repo/migrations/20260523000000_add_instance_setup_and_promote_first_admin.exs
@@ -1,0 +1,42 @@
+defmodule Comcent.Repo.Migrations.AddInstanceSetupAndPromoteFirstAdmin do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE TABLE IF NOT EXISTS "instance_setup" (
+      "id"                  INTEGER   NOT NULL DEFAULT 1,
+      "token"               TEXT,
+      "generated_at"        TIMESTAMP,
+      "consumed_at"         TIMESTAMP,
+      "consumed_by_user_id" TEXT,
+      "created_at"          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      "updated_at"          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      CONSTRAINT "instance_setup_pkey"        PRIMARY KEY ("id"),
+      CONSTRAINT "instance_setup_singleton"   CHECK ("id" = 1),
+      CONSTRAINT "instance_setup_user_fkey"   FOREIGN KEY ("consumed_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL
+    )
+    """)
+
+    # Upgrade safety: if any user exists but none is super_admin, promote the
+    # earliest-created user. This prevents an existing CE install from locking
+    # itself out the moment the gated signup goes live.
+    execute("""
+    UPDATE "users"
+    SET "is_super_admin" = true,
+        "updated_at"     = CURRENT_TIMESTAMP
+    WHERE "id" = (
+      SELECT "id"
+      FROM "users"
+      ORDER BY "created_at" ASC
+      LIMIT 1
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM "users" WHERE "is_super_admin" = true
+    )
+    """)
+  end
+
+  def down do
+    execute("DROP TABLE IF EXISTS \"instance_setup\"")
+  end
+end


### PR DESCRIPTION
## Summary

Open signup on a self-hosted CE instance meant anyone who found the URL could register and spin up their own org on someone else's install. This locks it down with the "first-run bootstrap admin → invite-only afterward" pattern used by GitLab/Sentry/Grafana.

- **First-run claim**: On boot, if no super-admin exists, a one-time setup token is auto-generated and printed to server logs (`docker compose logs server`). Operator visits `/setup`, enters the token + super-admin details + org details. Token is consumed once.
- **Post-claim signup gate**: `POST /api/v2/auth/register` and the OAuth callback both require either (a) a pending `OrgInvite` for the email, or (b) email domain in `ALLOWED_SIGNUP_DOMAIN` (comma-separated env var). Empty by default → strict invite-only.
- **Org creation lockdown**: `POST /user/orgs` now requires `is_super_admin` so an invited member can't spin up parallel orgs on the install.
- **Upgrade safety**: The migration promotes the earliest existing user to `is_super_admin` when no super-admin exists, so already-populated installs don't lock themselves out on upgrade.
- **Frontend**: New `/setup` SvelteKit route; `/login` redirects to `/setup` when `bootstrapMode === true`.
- **Ops escape hatch**: `mix comcent.reset_setup_token` (with `--force` after consumption) if the token gets lost.

## Test plan

- [x] Fresh DB: server startup prints boxed setup-token banner; `/` and `/login` redirect to `/setup`.
- [x] Claim form with valid token → super-admin + org + `OrgMember` ADMIN created; token marked consumed; JWT issued; landed at `/app`.
- [x] Restart after claim: banner no longer prints; `bootstrapMode` = `false`; `/setup` redirects to `/login`.
- [x] `POST /api/v2/auth/register` with a random email → 403 with invite-only message.
- [ ] Set `ALLOWED_SIGNUP_DOMAIN=example.com`, restart, register with matching email → 200.
- [ ] Register email that has a pending `OrgInvite` → 200.
- [ ] Non-super-admin `POST /user/orgs` → 403.
- [x] Existing install with users: earliest user auto-promoted to super_admin; no token printed.
- [ ] `mix comcent.reset_setup_token` post-claim → refuses without `--force`; regenerates with it.

## Notes

- The email-verification skip on the first admin (`is_email_verified: true` in the claim) is intentional — the operator controls the server, so a mail round-trip only adds friction.
- I did not touch `install.sh`; the token surfaces via server logs on first boot. If desired, we can add a "watch for the setup token" hint after the container starts in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)