### PR TITLE
Rewrite README for first-time installers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Comcent CE
+
+Thanks for your interest in contributing!
+
+## Tech stack
+
+- **Backend**: Elixir + Phoenix
+- **Frontend**: SvelteKit
+- **SBC**: Go
+- **Media**: FreeSWITCH
+- **Infra**: Postgres, Redis, RabbitMQ
+
+## Run locally (development)
+
+```bash
+git clone https://github.com/comcent-io/comcent-ce.git
+cd comcent-ce
+cp .env.example .env          # fill in secrets / API keys you have
+docker compose up             # pulls prebuilt images and starts the stack
+```
+
+Open <http://localhost:6173>, sign up, and start playing.
+
+## CLA
+
+A CLA signature is required before your PR is merged. The CLA bot will
+comment on your PR with a link to sign.
+
+## License
+
+Contributions are accepted under the project's AGPL-3.0 license. See
+`LICENSE`.

--- a/README.md
+++ b/README.md
@@ -1,151 +1,147 @@
 # Comcent Community Edition
 
-Open-source CPaaS / contact-center platform. Elixir + Phoenix backend,
-SvelteKit frontend, Go SBC, FreeSWITCH media, Postgres + Redis + RabbitMQ.
+Run your own call center on a single Linux box. Bring your own SIP trunk
+(Twilio, Telnyx, …), run one install script, and you get:
 
-> Self-host the whole thing on a single Linux box with one `curl | bash`,
-> bring your own SIP trunk, and you have a working call center with browser
-> dialers, SIP trunks, queues, recording, transcription, and an AI voice
-> bot.
+- Voice calls with browser-based dialers for agents
+- Phone numbers, queues, call recording
+- Call transcription, AI summaries, sentiment, semantic search
+- A real-time AI voice bot
+- Multi-tenant orgs, API keys, webhooks
 
-## Try it locally (development)
+> 🎬 **[Placeholder: under-a-minute video — from blank server to first call]**
 
-For contributors and folks just kicking the tyres on a laptop:
+## Minimum requirements
 
-```bash
-git clone https://github.com/comcent-io/comcent-ce.git
-cd comcent-ce
-cp .env.example .env          # fill in secrets / API keys you have
-docker compose up             # pulls prebuilt images and starts the stack
-```
+- A Linux host with a public IPv4 — Ubuntu 22.04+ / Debian 12+ (a $12/mo
+  DigitalOcean droplet with 2 vCPU / 4 GB RAM is plenty)
+- A domain name you can point at it
+- A SIP trunk (Twilio, Telnyx, Bandwidth, …) if you want to make/receive
+  real phone calls
 
-Open <http://localhost:6173>, sign up, and start playing.
+## Install
 
-## Deploy on a server (production)
+### 1. Open the firewall
 
-The supported one-shot path. Tested on a fresh DigitalOcean droplet (Ubuntu
-24.04, $12/mo 4 GB / 2 vCPU is plenty), works on any cloud / bare-metal
-Linux host with a public IP.
-
-### 1. Provision a Linux host
-
-- Ubuntu 22.04+ or Debian 12+ (any modern distro with Docker support works)
-- Public IPv4
-- 2 vCPU / 4 GB RAM is the practical minimum
-- Open inbound on the firewall (cloud or `ufw`):
-
-  | Port | Protocol | What |
-  |---|---|---|
-  | 80, 443 | TCP | HTTP / HTTPS — app + Let's Encrypt cert issuance |
-  | 5060 | UDP + TCP | SIP signaling |
-  | 5063 | TCP | SIP-over-WSS (browser dialer) |
-  | 19000–19100 | UDP | RTP media |
-
-  On DigitalOcean, this is the **Cloud Firewall** under Networking → Firewalls.
+| Port | Protocol | What |
+| --- | --- | --- |
+| 80, 443 | TCP | HTTP / HTTPS — app + Let's Encrypt cert issuance |
+| 5060 | UDP + TCP | SIP signaling |
+| 5063 | TCP | SIP-over-WSS (browser dialer) |
+| 19000–19100 | UDP | RTP media |
 
 ### 2. Point a domain at the host
 
-Pick a hostname like `cpaas.yourdomain.com`. Create a DNS **A record** that
-points it at the droplet's public IPv4. Wait for it to propagate (usually
-under a minute, sometimes a few minutes — check with `dig +short
-cpaas.yourdomain.com`). Let's Encrypt's HTTP-01 challenge will hit this
-hostname on `:80` and fail until DNS points correctly, so don't skip this.
+Create a DNS **A record** (e.g. `cpaas.yourdomain.com`) pointing at the
+host's public IPv4. Verify with `dig +short cpaas.yourdomain.com` before
+continuing — the HTTPS certificate can't be issued until DNS resolves.
 
-### 3. (Optional) Set up your SIP trunk
+### 3. Run the installer
 
-If you're bringing your own trunk (Twilio, Telnyx, Bandwidth, your own
-Kamailio, …) this is the time:
-
-- **Twilio Elastic SIP Trunking** (the path we test against):
-  - Create a Trunk if you don't have one — note the **Termination URI**
-    (e.g. `mytrunk.pstn.twilio.com`).
-  - **Authentication → IP Access Control Lists** → add the droplet's
-    public IP (`<YOUR_IP>/32`). Both inbound and outbound traffic gate on
-    this list.
-  - **Origination → Origination URIs** → add
-    `sip:<YOUR_DOMAIN>?transport=udp` (priority 10, weight 10) so calls to
-    your numbers reach the droplet.
-  - Buy a phone number and assign it to the trunk.
-- **Other trunks**: same idea — whitelist the droplet IP on the trunk
-  side, point inbound calls to the droplet's public hostname over UDP/5060.
-
-You'll plug the trunk's termination FQDN into the dashboard once the stack
-is up (Settings → SIP trunks → New).
-
-### 4. Run the installer
-
-SSH into the host as root (or any user that can run docker without sudo):
+SSH into the host and run:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/comcent-io/comcent-ce/main/install.sh | bash
 ```
 
-What it does (≈30 seconds, no prompts):
+Takes ~30 seconds: installs Docker if missing, generates secrets, and
+writes `docker-compose.yaml` + `.env` into `~/comcent-ce/`. It does **not**
+start anything yet.
 
-- Installs Docker via `https://get.docker.com` if missing.
-- Auto-detects your public IP.
-- Generates strong random secrets for Postgres / RabbitMQ / API / signing
-  keys.
-- Downloads `docker-compose.yaml` and writes `.env` (mode 600) into
-  `~/comcent-ce/`.
-- Stops there. **Does not start the stack** — you edit `.env` first.
-
-### 5. Edit `.env`
+### 4. Fill in `.env`
 
 ```bash
 nano ~/comcent-ce/.env
 ```
 
-Search for the string `replaceMe` and fill every one in:
+Search for `replaceMe` and fill every one in:
 
 | Variable | What |
-|---|---|
-| `COMCENT_DOMAIN` | The hostname from step 2 (e.g. `cpaas.yourdomain.com`) |
-| `LETSENCRYPT_EMAIL` | Your email for cert-renewal alerts |
+| --- | --- |
+| `COMCENT_DOMAIN` | Your hostname from step 2 |
+| `LETSENCRYPT_EMAIL` | Email for cert-renewal alerts |
 | `SOURCE_EMAIL` | Sender for invites / password resets |
-| `SMTP_URL` | `smtp://user:pass@host:port` — any provider works (SES, SendGrid, Postmark, Mailgun, your own postfix). Leave blank to disable email entirely (you can still sign up the first user from the CLI). |
-| `STORAGE_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | S3 (or any S3-compatible) bucket for call recordings & uploads |
+| `SMTP_URL` | `smtp://user:pass@host:port` — any provider works. Leave blank to disable email. |
+| `STORAGE_BUCKET_NAME`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | S3 (or S3-compatible) bucket for recordings & uploads |
 
-Optional, leave blank to disable:
-- `DEEPGRAM_API_KEY` — real-time transcription, voice bot
-- `OPENAI_API_KEY` — AI summaries, voice bot
-- `SERVER_SENTRY_DSN`, `PUBLIC_SENTRY_DSN` — error tracking
+Optional (leave blank to disable): `DEEPGRAM_API_KEY` (transcription,
+voice bot), `OPENAI_API_KEY` (AI summaries, voice bot), Sentry DSNs.
 
-Don't touch the auto-detected / generated section unless you know what
-you're changing.
-
-### 6. Start the stack
+### 5. Start it and claim your instance
 
 ```bash
 cd ~/comcent-ce
 docker compose up -d
-docker compose logs -f server
 ```
 
-First run pulls ≈800 MB of images and takes 5–10 minutes — that's normal,
-not stuck. Watch the server log until it stops scrolling and you see
-`Phoenix endpoint listening`.
+First run pulls ≈800 MB of images and takes 5–10 minutes — that's normal.
+The HTTPS certificate is issued about a minute after start.
 
-Let's Encrypt issues the cert about a minute after first start (HTTP-01
-challenge against your DNS A record from step 2). Then open
-<https://cpaas.yourdomain.com> and sign up.
-
-### 7. Verify TLS on both surfaces
+Once up, the server prints a one-time **setup token** for creating the
+first admin account. Grab it from the logs:
 
 ```bash
-# HTTPS app
-echo | openssl s_client -connect cpaas.yourdomain.com:443 -servername cpaas.yourdomain.com 2>/dev/null \
-  | openssl x509 -noout -subject -issuer -dates
-
-# SIP-over-WSS (used by browser dialer)
-echo | openssl s_client -connect cpaas.yourdomain.com:5063 -servername cpaas.yourdomain.com 2>/dev/null \
-  | openssl x509 -noout -subject -issuer -dates
+docker compose logs server | grep -A 10 "FIRST-RUN SETUP"
 ```
 
-Both should show `issuer= /C=US/O=Let's Encrypt/...` and a 90-day validity
-window.
+Then open `https://cpaas.yourdomain.com/setup`, enter the token along with
+your name, email, password, and organization details. Done — you're the
+super-admin.
 
-### 8. Upgrade later
+(Lost the token? It's re-printed on every server start until claimed —
+`docker compose restart server`, then grep again.)
+
+### 6. Connect your SIP trunk
+
+To make and receive real phone calls, open **Sip Trunk** in the sidebar,
+hit **Create**, and fill in:
+
+- **Name** — anything, e.g. `twilio`.
+- **Provide Outbound Credentials** — tick only if your trunk uses
+  username/password auth instead of IP-based auth.
+- **SIP Proxy Address** — your provider's termination URI
+  (e.g. `mytrunk.pstn.twilio.com`).
+- **Inbound IPs to whitelist** — comma-separated IPs/domains your provider
+  sends calls from.
+
+On the trunk provider's side:
+
+- Whitelist your host's public IP (`<YOUR_IP>/32`) — e.g. Twilio's
+  **IP Access Control Lists** on an Elastic SIP Trunk.
+- Point inbound calls (Origination) at `sip:<YOUR_DOMAIN>?transport=udp`.
+- Route your phone number to the trunk, so calls to it reach this server.
+  Every provider names this differently — on Twilio you assign the number
+  to the Elastic SIP Trunk.
+
+### 7. Add the number and build its inbound flow
+
+Routing the number to the trunk on the provider's side isn't enough —
+Comcent also needs to know the number and what to do with calls to it.
+Open **Numbers** in the sidebar, hit **Add**, and fill in:
+
+- **Name** — a friendly label.
+- **Number (E.164)** — the number you bought, e.g. `+15551234567`.
+- **SIP Trunk** — pick the trunk from step 6.
+- **Allow Outbound if destination matches regex** — optional; restrict
+  which destinations can be dialed from this number
+  (e.g. `^\+1[0-9]{10}$` for US only).
+
+Then build the **inbound flow** in the graph editor below — it decides
+what happens when someone calls the number:
+
+1. **Add step** and pick a node: **Queue** (route to agents in a queue —
+   create one under **Queues** first), **Dial** / **DialGroup** (ring
+   specific agents), **Menu** (IVR keypad menu), **Play** (play audio),
+   **WeekTime** (business-hours branching), or **VoiceBot** (AI voice
+   bot — needs the Deepgram/OpenAI keys from step 4).
+2. Drag it into place.
+3. Connect **Start** to the first node, and node outlets onward.
+
+The simplest working flow is **Start → Dial** with **To** set to your own
+username (the SIP username you chose during setup). Hit **Add** to save,
+then call your number — it rings in your browser dialer.
+
+## Upgrade
 
 ```bash
 cd ~/comcent-ce
@@ -153,55 +149,40 @@ docker compose pull
 docker compose up -d
 ```
 
-Migrations run on every server start automatically.
-
-## What's in CE
-
-- Voice calls, queues, phone numbers, SIP trunks, recording
-- Multi-tenant orgs, password + OIDC auth
-- API keys, webhooks
-- Real-time voice bot (Deepgram + OpenAI)
-- Call transcription, AI summaries, sentiment, semantic search
-
-## What's in EE (<https://comcent.io/enterprise>)
-
-- Billing, wallet, metered usage
-- GDPR compliance workflows
-- Audit logs, SLA tracking
-- Outbound campaigns, daily executive summaries
+Migrations run automatically on every server start.
 
 ## Troubleshooting
 
-**Sign-up email never arrives.** `SMTP_URL` is unset or wrong. Either fix
-it, or for one-off testing, run a Mailhog catcher:
-
-```bash
-docker run -d --name mailhog --network comcent-network -p 8025:8025 \
-  mailhog/mailhog:latest
-# in ~/comcent-ce/.env: SMTP_URL=smtp://mailhog:1025
-docker compose up -d server     # reload env
-# open http://<host>:8025 to see captured emails
-```
-
-> ⚠ Mailhog's UI has no auth. Either bind to `127.0.0.1:8025` and SSH-tunnel,
-> or only run on a one-off test droplet you're going to destroy.
+**Sign-up email never arrives.** `SMTP_URL` is unset or wrong. For one-off
+testing you can run a [Mailhog](https://github.com/mailhog/MailHog)
+container and set `SMTP_URL=smtp://mailhog:1025`.
 
 **`https://...` shows a Traefik default cert.** Let's Encrypt couldn't
-issue. Check `docker compose logs traefik` for the ACME error — usually
-DNS not yet pointing at the host, or port 80 blocked.
+issue. Check `docker compose logs traefik` — usually DNS not yet pointing
+at the host, or port 80 blocked.
 
-**SIP trunk returns 403 on outbound.** The droplet's public IP is not on
-the trunk's IP Access Control List. Add `<your-droplet-IP>/32` to the
-trunk's allow list.
+**SIP trunk returns 403 on outbound.** Your host's public IP is not on the
+trunk's IP allow list. Add `<your-IP>/32`.
 
-**Browser dialer can't register.** The agent's WebRTC client connects to
-`wss://<COMCENT_DOMAIN>:5063/sip-ws`. Confirm port 5063/TCP is open in your
-firewall and that step 7 above showed a valid LE cert on that port.
+**Browser dialer can't register.** The dialer connects to
+`wss://<COMCENT_DOMAIN>:5063/sip-ws`. Confirm port 5063/TCP is open and
+serving a valid Let's Encrypt cert:
+
+```bash
+echo | openssl s_client -connect cpaas.yourdomain.com:5063 -servername cpaas.yourdomain.com 2>/dev/null \
+  | openssl x509 -noout -subject -issuer -dates
+```
+
+## Enterprise Edition
+
+Billing & metered usage, GDPR workflows, audit logs, SLA tracking,
+outbound campaigns, executive summaries → <https://comcent.io/enterprise>
 
 ## License
 
 AGPL-3.0. See `LICENSE`. Commercial licenses available — contact the
 maintainer.
 
-Contributors: a CLA signature is required before your PR is merged. The
-CLA bot will comment on your PR with a link to sign.
+## Contributing
+
+Want to hack on Comcent CE itself? See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/server/lib/comcent_web/controllers/internal/dialplan_controller.ex
+++ b/server/lib/comcent_web/controllers/internal/dialplan_controller.ex
@@ -99,7 +99,8 @@ defmodule ComcentWeb.Internal.DialplanController do
               if member do
                 {:ok,
                  dial_member_dialplan(member, subdomain, "default", %{
-                   address: "#{from_user}@#{caller_subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}",
+                   address:
+                     "#{from_user}@#{caller_subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}",
                    name: caller_member[:user][:name] || ""
                  })}
               else
@@ -117,7 +118,8 @@ defmodule ComcentWeb.Internal.DialplanController do
 
               {:ok,
                dial_member_dialplan(member, caller_subdomain, "default", %{
-                 address: "#{from_user}@#{caller_subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}",
+                 address:
+                   "#{from_user}@#{caller_subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}",
                  name: caller_member[:user][:name] || ""
                })}
             else
@@ -217,7 +219,9 @@ defmodule ComcentWeb.Internal.DialplanController do
                 else
                   # external redirect
                   Logger.info("External redirect found.")
-                  {:ok, dial_trunk_dialplan(number, destination_number, number.org.subdomain, context)}
+
+                  {:ok,
+                   dial_trunk_dialplan(number, destination_number, number.org.subdomain, context)}
                 end
               end
             end
@@ -500,7 +504,7 @@ defmodule ComcentWeb.Internal.DialplanController do
     """
   end
 
-  defp dial_trunk_dialplan(number, to_user, subdomain, context \\ "default") do
+  defp dial_trunk_dialplan(number, to_user, subdomain, context) do
     # Get dial string from DialUtils
     dial_string =
       DialUtils.create_dial_string_for_sip_trunk(


### PR DESCRIPTION
## Summary
- Refocus the README on someone installing and testing CE for the first time: plain-language intro (no tech-stack jargon), a placeholder for an under-a-minute demo video, minimum requirements up front, then the install steps.
- Verify install steps against the actual code/UI: first-run setup-token claim flow (grep the `FIRST-RUN SETUP` banner, claim at `/setup`), SIP trunk form fields in their real order, and a new step for adding a number + building its inbound flow graph (simplest flow: Start → Dial to your own username).
- Move contributor-facing content (tech stack, local dev setup, CLA) to a new `CONTRIBUTING.md`, linked at the end of the README.
- Drop a never-used default argument in `dial_trunk_dialplan/4` that failed the pre-commit `mix compile --warnings-as-errors` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)