### PR TITLE
CI: make integration tests actually run

### DIFF
--- a/.env.e2e.ci
+++ b/.env.e2e.ci
@@ -1,0 +1,42 @@
+# e2e stack env — mirrors .env.example + .env.e2e.example overrides
+SOURCE_EMAIL="Comcent <noreply@comcent.local>"
+PUBLIC_BASE_URL=http://localhost:4173
+PUBLIC_SIP_WS_URL=ws://localhost:4180
+DATABASE_URL=postgresql://postgres:password@localhost:55432/postgres
+STORAGE_BUCKET_NAME=comcent-storage-dev
+RABBITMQ_URL=amqp://kotappa:password@rabbitmq
+BUCKET_REGION=us-east-1
+AWS_ACCESS_KEY_ID=miniotestkey
+AWS_SECRET_ACCESS_KEY=miniotestsecret123
+S3_ENDPOINT_URL=http://minio:9000
+S3_PROXY_DOWNLOADS=true
+AUTH_PASSWORD_ENABLED=true
+AUTH_OIDC_PROVIDERS_JSON={}
+SMTP_URL=smtp://mailhog:1025
+INTERNAL_API_BASE_URL=http://server:4000/internal-api
+INTERNAL_API_USERNAME=internal_api
+INTERNAL_API_PASSWORD=e2e-internal-password
+REDIS_URL=redis://redis
+FS_LOCAL_NETWORK=172.29.0.0/16
+RPC_API_TOKEN=e2e-rpc-token
+SBC_IP=172.29.17.9
+ENV=e2e
+E2E_APP_PORT=4173
+E2E_SERVER_PORT=4400
+E2E_POSTGRES_PORT=55432
+E2E_RABBITMQ_PORT=55672
+E2E_RABBITMQ_MANAGEMENT_PORT=55673
+E2E_REDIS_PORT=56379
+E2E_MAILHOG_SMTP_PORT=51025
+E2E_MAILHOG_HTTP_PORT=58025
+POSTGRES_SSL_ENABLED=false
+# Dummy keys — used only inside the throwaway CI e2e stack, never in a real
+# deployment. Do not reuse.
+SIGNING_KEY=8f4be3f2b0f7cbd4a1a0e9c9c6b0d1a2e3f4a5b6c7d8e9f0a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718
+SECRET_KEY_BASE=e2e-only-dummy-secret-key-base-0123456789abcdef0123456789abcdef0123456789abcdef
+# Instance is claimed by the seeded super-admin; test signups use @example.com
+ALLOWED_SIGNUP_DOMAIN=example.com
+# Telephony specs register SIP users under <org>.comcent.io
+SIP_USER_ROOT_DOMAIN=comcent.io
+# Web dialer derives its SIP domain from this (falls back to PUBLIC_BASE_URL host)
+PUBLIC_SIP_USER_ROOT_DOMAIN=comcent.io

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
+      # .env.e2e.ci is committed and contains only dummy values scoped to the
+      # throwaway CI stack — no repo secrets/vars needed, so fork PRs work too.
       - name: Add e2e env file
-        run: |
-          cat > .env.e2e <<HEREDOCS
-          ${{ vars.TEST_DOT_ENV }}
-          ${{ vars.TEST_PLAYWRIGHT_ENV }}
-          HEREDOCS
+        run: cp .env.e2e.ci .env.e2e
 
       - name: Start isolated e2e stack
         run: npm run test:e2e:stack:up
 
+      # e2e/ is not a root workspace, so its deps (incl. @playwright/test)
+      # need their own install.
       - name: Install dependencies
-        run: npm install
+        run: npm install && npm install --prefix e2e
 
       - name: Install Playwright
         run: npx playwright install --with-deps
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 .env.*
 !.env.example
 !.env.e2e.example
+!.env.e2e.ci
 .turbo
 .venv
 .DS_Store

--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -7,6 +7,11 @@ services:
       - POSTGRES_PASSWORD=password
     ports:
       - '${E2E_POSTGRES_PORT:-55432}:5432'
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      interval: 2s
+      timeout: 3s
+      retries: 30
     networks:
       - comcent-network
 
@@ -84,11 +89,16 @@ services:
       - SMTP_URL=smtp://mailhog:1025
     command: sh -c "/app/bin/migrate && /app/bin/server start"
     depends_on:
-      - postgres
-      - rabbitmq
-      - redis
-      - minio-init
-      - mailhog
+      postgres:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_started
+      redis:
+        condition: service_started
+      minio-init:
+        condition: service_started
+      mailhog:
+        condition: service_started
     healthcheck:
       test:
         ['CMD', 'curl', '--fail', '--silent', 'http://127.0.0.1:4000/health']
@@ -151,7 +161,7 @@ services:
       - INTERNAL_API_USERNAME=${INTERNAL_API_USERNAME:-}
       - INTERNAL_API_PASSWORD=${INTERNAL_API_PASSWORD:-}
       - RPC_API_TOKEN=${RPC_API_TOKEN:-}
-      - SIP_USER_ROOT_DOMAIN=localhost
+      - SIP_USER_ROOT_DOMAIN=${SIP_USER_ROOT_DOMAIN:-localhost}
     ports:
       - '${E2E_SBC_WS_PORT:-4180}:80'
     depends_on:

--- a/e2e/authFlowTest.spec.ts
+++ b/e2e/authFlowTest.spec.ts
@@ -31,12 +31,8 @@ test('Password signup, email verification, and login flow works', async ({
     waitUntil: 'networkidle',
   });
 
-  await expect(page).toHaveURL('/terms-conditions');
-  await expect(
-    page.getByText('Terms of Service and Privacy Policy'),
-  ).toBeVisible();
-
-  await page.getByRole('button', { name: 'I accept' }).click();
+  // CE has no terms-and-conditions gate after signup — email verification
+  // lands straight on the org picker.
   await page.waitForURL('/org');
 
   await clearSession(page);

--- a/e2e/orgSwitcherTest.spec.ts
+++ b/e2e/orgSwitcherTest.spec.ts
@@ -15,19 +15,14 @@ test('Home page, switch organization successfully', async ({ page }) => {
   await page.getByPlaceholder('your.name').fill('aiet');
   await page.getByPlaceholder('ACME Corp').fill('Alvas');
   await page.getByPlaceholder('acme', { exact: true }).fill('aiet');
-  await page.getByPlaceholder('Billing Name').fill('aiet');
-  await page.getByLabel('Country').selectOption('IN');
-  await page.getByLabel('State').selectOption('Karnataka');
-  await page.getByPlaceholder('City').click();
-  await page.getByPlaceholder('City').fill('Moodbidri');
-  await page.getByLabel('Zip Code').click();
-  await page.getByLabel('Zip Code').fill('574227');
+  // CE org creation has no billing address fields; success returns to the
+  // org picker rather than the billing page.
   await page.getByRole('button', { name: 'Create Organization' }).click();
+  await page.waitForURL('/org');
+  await page.goto('/app/acme');
   await page.getByRole('button', { name: 'Switch Organization' }).click();
   await page.locator('#switchOrganization').selectOption('aiet');
-  await expect(page).toHaveURL(
-    '/app/aiet/settings/billing/balance?redirected=true',
-  );
+  await expect(page).toHaveURL('/app/aiet');
   await page.getByRole('button', { name: 'Switch Organization' }).click();
   await page.locator('#switchOrganization').selectOption('acme');
   await expect(page).toHaveURL('/app/acme');

--- a/e2e/utils/bootstrap.ts
+++ b/e2e/utils/bootstrap.ts
@@ -61,10 +61,11 @@ export async function seedBaselineData() {
         is_email_verified,
         has_agreed_to_tos,
         agreed_to_tos_at,
+        is_super_admin,
         created_at,
         updated_at
       )
-      VALUES ($1, $2, $3, true, true, $4, $4, $4)
+      VALUES ($1, $2, $3, true, true, $4, true, $4, $4)
     `,
       [userId, 'Test Admin', 'test.admin@example.com', now],
     );


### PR DESCRIPTION
## Summary
Integration tests have been red since the repo was created — the workflow interpolated `TEST_DOT_ENV`/`TEST_PLAYWRIGHT_ENV` repo variables that were never set, so `.env.e2e` was empty and the server container exited at boot before Playwright ever ran.

This PR fixes the full chain, verified locally against the same compose stack CI uses:

- **Committed `.env.e2e.ci`** (dummy-only values, safe for a public repo) copied to `.env.e2e` in CI — no repo variables needed, fork PRs work
- **`POSTGRES_SSL_ENABLED=false`** — the server defaults to SSL and the e2e postgres doesn't speak it
- **Postgres healthcheck** + server `depends_on: service_healthy` — migrate used to race postgres init and lose on cold runners
- **SIP root domain `comcent.io`** for server, SBC and web dialer — specs hardcode `acme.comcent.io` and the SBC rejects other domains with 403
- **Seed admin as `super_admin`** + `ALLOWED_SIGNUP_DOMAIN=example.com` so the setup-token gating doesn't block test signups
- **Install `e2e/` deps in CI** — `e2e` isn't a root workspace, so root `npm install` never installed `@playwright/test`
- **Spec updates** for intentional CE changes: no ToS gate after signup (71bca90), no billing fields on org creation (b6af807)

## Test plan
Full suite run locally three times against the CI compose stack: **99/104 pass**. The 5 remaining failures (agentOutbound, agentToAgent, holdResume, recordingContent, trunkAuth) are a pre-existing product bug — WebRTC-agent-originated calls connect/record fine but no `call_stories` row is written for `direction=outbound` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)