### PR TITLE
CI: install Playwright browsers for the e2e package's version

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Install dependencies
         run: npm install && npm install --prefix e2e
 
+      # Install browsers for e2e/'s own @playwright/test version — the root
+      # install doesn't match it and tests fail with missing chromium.
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx --prefix e2e playwright install --with-deps
 
       - name: Run Playwright tests
         id: playwright


### PR DESCRIPTION
## Summary
Follow-up to #15: the browser install step ran `npx playwright install` at the repo root, but the suite executes with `e2e/`'s own `@playwright/test`, whose browser build (chromium_headless_shell-1217) was never downloaded — global.setup failed and 103 tests didn't run. Install with `--prefix e2e` so the browsers match the version that actually runs.

## Test plan
Merge push runs Integration tests on main; expected outcome is the locally-verified 99/104 (5 known outbound-call-story failures, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)