### PR TITLE
CI: stack diagnostics, 4 e2e workers + retry on CI

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -42,6 +42,26 @@ jobs:
           path: e2e/playwright-report/
           retention-days: 30
 
+      - name: Collect stack diagnostics
+        if: always()
+        run: |
+          mkdir -p stack-logs
+          for s in server freeswitch sbc rabbitmq postgres; do
+            docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e logs --no-color --tail=400 $s > stack-logs/$s.log 2>&1 || true
+          done
+          docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e ps > stack-logs/ps.txt 2>&1 || true
+          docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e exec -T postgres \
+            psql -U postgres -c "SELECT direction, count(*) FROM call_stories GROUP BY 1" \
+            > stack-logs/call-stories.txt 2>&1 || true
+
+      - name: Upload stack diagnostics
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: stack-logs
+          path: stack-logs/
+          retention-days: 7
+
       - name: Tear down stack
         if: always()
         run: npm run test:e2e:stack:down

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,12 +47,17 @@ jobs:
         run: |
           mkdir -p stack-logs
           for s in server freeswitch sbc rabbitmq postgres; do
-            docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e logs --no-color --tail=400 $s > stack-logs/$s.log 2>&1 || true
+            docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e logs --no-color $s 2>&1 | gzip > stack-logs/$s.log.gz || true
           done
           docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e ps > stack-logs/ps.txt 2>&1 || true
+          docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e exec -T rabbitmq \
+            sh -c "rabbitmqctl list_queues name messages consumers; rabbitmqctl list_exchanges name type; rabbitmqctl list_bindings" \
+            > stack-logs/rabbitmq-state.txt 2>&1 || true
           docker compose -f docker-compose-e2e.yaml --env-file .env.e2e -p comcent-e2e exec -T postgres \
             psql -U postgres -c "SELECT direction, count(*) FROM call_stories GROUP BY 1" \
-            > stack-logs/call-stories.txt 2>&1 || true
+                             -c "SELECT count(*) AS call_story_events FROM call_story_events" \
+                             -c "SELECT count(*) AS call_spans FROM call_spans" \
+            > stack-logs/db-counts.txt 2>&1 || true
 
       - name: Upload stack diagnostics
         uses: actions/upload-artifact@v7

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,10 +21,7 @@ export default defineConfig({
   testMatch: '**/*.{spec,setup}.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  // Keep CI parallelism low: GitHub runners share a few cores with the whole
-  // telephony stack (FreeSWITCH media, SBC, sipp, recordings), and story
-  // processing falls behind test timeouts when saturated.
-  workers: process.env.CI ? 3 : 6,
+  workers: process.env.CI ? 8 : 6,
   reporter: process.env.PLAYWRIGHT_REPORTER || 'line',
   use: {
     baseURL: process.env.PUBLIC_ROOT_URL || 'http://localhost:4173',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,9 +21,11 @@ export default defineConfig({
   testMatch: '**/*.{spec,setup}.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 8 : 6,
-  // One retry on CI absorbs timing flakes in the telephony stress specs on
-  // shared runners; trace capture below already assumes retries exist.
+  // 4 workers on CI: at 8, a different sipp telephony spec fails each run
+  // from timing variance on the shared runner (queueStress, queueFailover, …).
+  workers: process.env.CI ? 4 : 6,
+  // One retry on CI absorbs residual timing flakes; trace capture below
+  // already assumes retries exist.
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.PLAYWRIGHT_REPORTER || 'line',
   use: {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 8 : 6,
+  // One retry on CI absorbs timing flakes in the telephony stress specs on
+  // shared runners; trace capture below already assumes retries exist.
+  retries: process.env.CI ? 1 : 0,
   reporter: process.env.PLAYWRIGHT_REPORTER || 'line',
   use: {
     baseURL: process.env.PUBLIC_ROOT_URL || 'http://localhost:4173',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -21,7 +21,10 @@ export default defineConfig({
   testMatch: '**/*.{spec,setup}.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  workers: process.env.CI ? 8 : 6,
+  // Keep CI parallelism low: GitHub runners share a few cores with the whole
+  // telephony stack (FreeSWITCH media, SBC, sipp, recordings), and story
+  // processing falls behind test timeouts when saturated.
+  workers: process.env.CI ? 3 : 6,
   reporter: process.env.PLAYWRIGHT_REPORTER || 'line',
   use: {
     baseURL: process.env.PUBLIC_ROOT_URL || 'http://localhost:4173',


### PR DESCRIPTION
## Summary
Follow-ups that took Integration tests from red to green after the freeswitch-ce awscli arch fix:

- **Stack diagnostics on every run**: full compose logs (gzipped), RabbitMQ queue/exchange/binding state, and call_stories/call_spans/call_story_events counts uploaded as a `stack-logs` artifact — this is what pinpointed the missing `comcent::s3UploadCompleted` events
- **4 Playwright workers on CI** (8 locally caused a different sipp telephony spec to fail each run from timing variance on shared runners)
- **1 retry on CI** — `trace: on-first-retry` already assumed retries existed

## Test plan
`workflow_dispatch` on this branch: [run 28732025847](https://github.com/comcent-io/comcent-ce/actions/runs/28732025847) — **all 104 specs passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)