### PR TITLE
chore: mix format pass over server/

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -126,11 +126,11 @@ if config_env() == :prod do
 
   host =
     System.get_env("PHX_HOST") ||
-      (case System.get_env("PUBLIC_BASE_URL") do
-         nil -> nil
-         "" -> nil
-         url -> URI.parse(url).host
-       end) ||
+      case System.get_env("PUBLIC_BASE_URL") do
+        nil -> nil
+        "" -> nil
+        url -> URI.parse(url).host
+      end ||
       "example.com"
 
   port = String.to_integer(System.get_env("PORT") || "4000")

--- a/server/lib/comcent/dial_utils.ex
+++ b/server/lib/comcent/dial_utils.ex
@@ -18,7 +18,10 @@ defmodule Comcent.DialUtils do
   def create_dial_targets_for_user(username, subdomain, channel_vars \\ nil) do
     sbc_sip_uri = sbc_sip_uri()
     sip_user_root_domain = Application.fetch_env!(:comcent, :sip_user_root_domain)
-    base_dial = "sofia/internal/#{username}@#{subdomain}.#{sip_user_root_domain};fs_path=#{sbc_sip_uri}"
+
+    base_dial =
+      "sofia/internal/#{username}@#{subdomain}.#{sip_user_root_domain};fs_path=#{sbc_sip_uri}"
+
     build_user_dial_targets(base_dial, channel_vars)
   end
 

--- a/server/lib/comcent/instance_setup.ex
+++ b/server/lib/comcent/instance_setup.ex
@@ -53,7 +53,8 @@ defmodule Comcent.InstanceSetup do
         token: token
       }) do
     with :ok <- validate_inputs(name, email, password, org_name, subdomain, sip_username, token),
-         {:ok, %{user: user}} <- run_claim_transaction(name, email, password, org_name, subdomain, sip_username, token) do
+         {:ok, %{user: user}} <-
+           run_claim_transaction(name, email, password, org_name, subdomain, sip_username, token) do
       {:ok, user}
     else
       {:error, _step, %Ecto.Changeset{} = changeset, _changes} ->
@@ -147,15 +148,29 @@ defmodule Comcent.InstanceSetup do
 
   defp validate_inputs(name, email, password, org_name, subdomain, sip_username, token) do
     cond do
-      blank?(name) -> {:error, "Name is required"}
-      blank?(email) -> {:error, "Email is required"}
+      blank?(name) ->
+        {:error, "Name is required"}
+
+      blank?(email) ->
+        {:error, "Email is required"}
+
       blank?(password) or String.length(password) < 8 ->
         {:error, "Password must be at least 8 characters"}
-      blank?(org_name) -> {:error, "Organization name is required"}
-      blank?(subdomain) -> {:error, "Subdomain is required"}
-      blank?(sip_username) -> {:error, "SIP username is required"}
-      blank?(token) -> {:error, "Setup token is required"}
-      true -> :ok
+
+      blank?(org_name) ->
+        {:error, "Organization name is required"}
+
+      blank?(subdomain) ->
+        {:error, "Subdomain is required"}
+
+      blank?(sip_username) ->
+        {:error, "SIP username is required"}
+
+      blank?(token) ->
+        {:error, "Setup token is required"}
+
+      true ->
+        :ok
     end
   end
 
@@ -168,10 +183,17 @@ defmodule Comcent.InstanceSetup do
     Multi.new()
     |> Multi.run(:setup_row, fn repo, _ ->
       case repo.get(InstanceSetup, @singleton_id) do
-        nil -> {:error, "Setup token is not configured. Restart the server."}
-        %InstanceSetup{consumed_at: %DateTime{}} -> {:error, "This instance has already been claimed."}
-        %InstanceSetup{token: stored} = row when stored == token -> {:ok, row}
-        _ -> {:error, "Invalid setup token."}
+        nil ->
+          {:error, "Setup token is not configured. Restart the server."}
+
+        %InstanceSetup{consumed_at: %DateTime{}} ->
+          {:error, "This instance has already been claimed."}
+
+        %InstanceSetup{token: stored} = row when stored == token ->
+          {:ok, row}
+
+        _ ->
+          {:error, "Invalid setup token."}
       end
     end)
     |> Multi.run(:no_super_admin, fn repo, _ ->
@@ -188,7 +210,8 @@ defmodule Comcent.InstanceSetup do
         {:ok, :ok}
       end
     end)
-    |> Multi.insert(:user,
+    |> Multi.insert(
+      :user,
       User.changeset(%User{id: user_id}, %{
         name: String.trim(name),
         email: normalized_email,
@@ -197,7 +220,8 @@ defmodule Comcent.InstanceSetup do
         is_super_admin: true
       })
     )
-    |> Multi.insert(:org,
+    |> Multi.insert(
+      :org,
       Org.changeset(%Org{id: org_id}, %{
         name: String.trim(org_name),
         subdomain: String.trim(subdomain),
@@ -206,7 +230,8 @@ defmodule Comcent.InstanceSetup do
         max_members: @trial_max_members
       })
     )
-    |> Multi.insert(:member,
+    |> Multi.insert(
+      :member,
       OrgMember.changeset(%OrgMember{}, %{
         user_id: user_id,
         org_id: org_id,

--- a/server/lib/comcent/queue/queue_manager.ex
+++ b/server/lib/comcent/queue/queue_manager.ex
@@ -31,7 +31,10 @@ defmodule Comcent.QueueManager do
     Repo.all(query)
     |> Enum.each(fn {queue_id, queue_name, subdomain} ->
       start_queue_manager_worker(queue_id, subdomain)
-      Logger.info("Started queue scheduler for #{queue_name}@#{subdomain}.#{sip_user_root_domain}")
+
+      Logger.info(
+        "Started queue scheduler for #{queue_name}@#{subdomain}.#{sip_user_root_domain}"
+      )
     end)
 
     Logger.info("\n=== Started queue scheduler processes ===\n")

--- a/server/lib/comcent_web/controllers/auth_controller.ex
+++ b/server/lib/comcent_web/controllers/auth_controller.ex
@@ -239,9 +239,7 @@ defmodule ComcentWeb.AuthController do
       ProviderConfig.signup_open_to_domain?(normalized) ->
         :ok
 
-      Repo.exists?(
-        from(i in OrgInvite, where: i.email == ^normalized and i.status == "PENDING")
-      ) ->
+      Repo.exists?(from(i in OrgInvite, where: i.email == ^normalized and i.status == "PENDING")) ->
         :ok
 
       true ->
@@ -474,10 +472,17 @@ defmodule ComcentWeb.AuthController do
         end
       end)
       |> case do
-        {:ok, user} -> {:ok, user}
-        {:error, :bootstrap_mode} -> {:error, "This instance has not been claimed yet. Visit /setup first."}
-        {:error, :signup_not_allowed} -> {:error, signup_not_allowed_message()}
-        {:error, reason} -> {:error, reason}
+        {:ok, user} ->
+          {:ok, user}
+
+        {:error, :bootstrap_mode} ->
+          {:error, "This instance has not been claimed yet. Visit /setup first."}
+
+        {:error, :signup_not_allowed} ->
+          {:error, signup_not_allowed_message()}
+
+        {:error, reason} ->
+          {:error, reason}
       end
     end
   end

--- a/server/lib/comcent_web/controllers/internal/configuration_controller.ex
+++ b/server/lib/comcent_web/controllers/internal/configuration_controller.ex
@@ -111,8 +111,12 @@ defmodule ComcentWeb.Internal.ConfigurationController do
     #      reach FS over symmetric-RTP / NAT-detected paths the same as before.
     sbc_deny =
       case System.get_env("SBC_IP") do
-        nil -> ""
-        "" -> ""
+        nil ->
+          ""
+
+        "" ->
+          ""
+
         entry ->
           cidr = if String.contains?(entry, "/"), do: entry, else: "#{entry}/32"
           ~s(<node type="deny" cidr="#{cidr}"/>)

--- a/server/lib/comcent_web/controllers/queue_controller.ex
+++ b/server/lib/comcent_web/controllers/queue_controller.ex
@@ -57,7 +57,9 @@ defmodule ComcentWeb.QueueController do
 
         Comcent.QueueManager.start_queue_manager_worker(queue.id, subdomain)
 
-        queue_address = "#{queue.id}@#{subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}"
+        queue_address =
+          "#{queue.id}@#{subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}"
+
         Logger.info("Started queue manager process for queue #{queue.name} at #{queue_address}")
 
         conn
@@ -289,7 +291,8 @@ defmodule ComcentWeb.QueueController do
           end
 
           # Stop a worker process for this queue under DynamicSupervisor
-          queue_address = "#{queue.id}@#{subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}"
+          queue_address =
+            "#{queue.id}@#{subdomain}.#{Application.fetch_env!(:comcent, :sip_user_root_domain)}"
 
           case Comcent.QueueManager.stop_queue_manager_worker(queue.id, subdomain) do
             :ok ->

--- a/server/lib/comcent_web/router.ex
+++ b/server/lib/comcent_web/router.ex
@@ -127,10 +127,6 @@ defmodule ComcentWeb.Router do
     get("/compliance/downloads/:file_name", FileController, :get_compliance_download)
     get("/uploads/get-signed-url", FileController, :get_upload_signed_url)
     delete("/uploads", FileController, :delete_upload)
-
-
-
-
   end
 
   scope "/api/v2/:subdomain", ComcentWeb do
@@ -203,7 +199,6 @@ defmodule ComcentWeb.Router do
 
   scope "/api/v2", ComcentWeb do
     pipe_through([:api])
-
   end
 
   pipeline :internal do


### PR DESCRIPTION
## Summary
Formatting-only output of `mix format` (the pre-commit hook formats all of `server/` on every commit, which left this churn in working trees). Case-clause rewrapping and blank-line cleanup — no logic changes; verified with `git diff -w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)