### PR TITLE
Add GitHub Sponsors support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: pavanputhra

--- a/README.md
+++ b/README.md
@@ -180,6 +180,17 @@ echo | openssl s_client -connect voice.yourdomain.com:5063 -servername voice.you
 Billing & metered usage, GDPR workflows, audit logs, SLA tracking,
 outbound campaigns, executive summaries → <https://comcent.io/enterprise>
 
+## Sponsor
+
+Comcent CE is free and AGPL-licensed. If it's saving you the cost of a
+call-center SaaS, consider sponsoring development — it funds the time
+spent maintaining and improving the community edition.
+
+👉 [GitHub Sponsors](https://github.com/sponsors/pavanputhra)
+
+See [SPONSORS.md](SPONSORS.md) for the people and companies already
+backing this project.
+
 ## License
 
 AGPL-3.0. See `LICENSE`. Commercial licenses available — contact the

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -1,0 +1,17 @@
+# Sponsors
+
+Comcent CE is free, AGPL-licensed, and maintained thanks to the people and
+companies who sponsor its development. If you'd like to join them, see
+[Sponsor](README.md#sponsor) in the README.
+
+## Partners
+
+_None yet — be the first!_
+
+## Champions
+
+_None yet — be the first!_
+
+## Backers
+
+_None yet — be the first!_


### PR DESCRIPTION
## Summary
- Adds a **Sponsor** section to the README linking to GitHub Sponsors and `SPONSORS.md`
- Adds `SPONSORS.md` to track Partners/Champions/Backers as they join
- Adds `.github/FUNDING.yml` so GitHub renders the native Sponsor button on the repo page

## Test plan
- [x] Verified README renders correctly (new section sits between Enterprise Edition and License)
- [ ] Confirm Sponsor button appears on the repo page after merge
- [ ] Confirm sponsor tiers/welcome messages are configured on github.com/sponsors/pavanputhra

🤖 Generated with [Claude Code](https://claude.com/claude-code)