### PR TITLE
Support pointing OpenAI/Deepgram at alternate endpoints (e.g. LiteLLM)

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -23,6 +23,12 @@ case System.get_env("DEEPGRAM_API_KEY") do
   _ -> :ok
 end
 
+# Base URL is separate from the key check above — self-hosters can point
+# this at any Deepgram-API-compatible endpoint (e.g. a local proxy) even
+# without changing the key.
+config :comcent, :deepgram,
+  base_url: System.get_env("DEEPGRAM_BASE_URL", "https://api.deepgram.com/v1")
+
 # AWS Configuration
 aws_access_key_id =
   System.get_env("AWS_ACCESS_KEY_ID", "")
@@ -77,6 +83,12 @@ case System.get_env("OPENAI_API_KEY") do
   key when is_binary(key) and key != "" -> config :comcent, :openai, api_key: key
   _ -> :ok
 end
+
+# Base URL is separate from the key check above — self-hosters can point
+# this at any OpenAI-API-compatible endpoint (e.g. a self-hosted LiteLLM
+# proxy) instead of OpenAI directly, even without changing the key.
+config :comcent, :openai,
+  base_url: System.get_env("OPENAI_BASE_URL", "https://api.openai.com")
 
 # ## Using releases
 #

--- a/server/lib/comcent/deepgram.ex
+++ b/server/lib/comcent/deepgram.ex
@@ -6,13 +6,16 @@ defmodule Comcent.Deepgram do
   use HTTPoison.Base
   require Logger
 
-  @base_url "https://api.deepgram.com/v1"
   @default_timeout 30_000
   # Receive timeout needs to be longer as Deepgram downloads and transcribes audio
   @default_recv_timeout 120_000
 
   def process_url(url) do
-    @base_url <> url
+    base_url() <> url
+  end
+
+  defp base_url do
+    Application.get_env(:comcent, :deepgram)[:base_url] || "https://api.deepgram.com/v1"
   end
 
   def process_request_headers(headers) do

--- a/server/lib/comcent/openai.ex
+++ b/server/lib/comcent/openai.ex
@@ -3,8 +3,9 @@ defmodule Comcent.OpenAI do
   alias HTTPoison
 
   def embed_text(text) do
-    openai_api_key = Application.get_env(:comcent, :openai)[:api_key]
-    url = "https://api.openai.com/v1/embeddings"
+    config = Application.get_env(:comcent, :openai)
+    openai_api_key = config[:api_key]
+    url = "#{config[:base_url] || "https://api.openai.com"}/v1/embeddings"
 
     headers = [
       {"Content-Type", "application/json"},
@@ -42,8 +43,9 @@ defmodule Comcent.OpenAI do
   Sends a chat completion request to OpenAI API
   """
   def chat_completion(messages, temperature \\ 0, model \\ "gpt-4o-mini") do
-    openai_api_key = Application.get_env(:comcent, :openai)[:api_key]
-    url = "https://api.openai.com/v1/chat/completions"
+    config = Application.get_env(:comcent, :openai)
+    openai_api_key = config[:api_key]
+    url = "#{config[:base_url] || "https://api.openai.com"}/v1/chat/completions"
 
     headers = [
       {"Content-Type", "application/json"},


### PR DESCRIPTION
## What this does

Both `Comcent.OpenAI` and `Comcent.Deepgram` had their API base URLs hardcoded to `api.openai.com` / `api.deepgram.com`, so self-hosters were locked into those providers directly.

Adds two new optional env vars:

- `OPENAI_BASE_URL` — defaults to `https://api.openai.com`
- `DEEPGRAM_BASE_URL` — defaults to `https://api.deepgram.com/v1`

Existing deployments are unaffected — both default to the real APIs if unset.

## Why

This lets you point OpenAI-API-compatible traffic at something other than OpenAI directly — most notably a self-hosted **LiteLLM** proxy, which can front many different LLM providers behind a single OpenAI-compatible interface. Same idea for Deepgram-compatible alternatives via `DEEPGRAM_BASE_URL`.

## Test plan

- [x] `mix compile --warnings-as-errors` passes
- [x] Verified the `config/3` merge behavior directly (API key config and base URL config are set in separate blocks — confirmed both land in the same keyword list correctly, with and without the API key env var present)
- [x] Manual smoke test against a real LiteLLM instance, proxying to Anthropic:
  - Ran a local LiteLLM proxy (`litellm-test`) with a `model_list` entry aliasing `gpt-4o-mini` → an Anthropic Claude model, backed by a real Anthropic API key
  - Confirmed the proxy itself responds correctly via a direct `curl` against `/v1/chat/completions`
  - Called `Comcent.OpenAI.chat_completion/1` directly (`mix run --no-start`, with `Application.put_env(:comcent, :openai, base_url: "http://localhost:4000", ...)`) — got back a real Claude-generated response, confirming the full path: configured base URL → `openai.ex` → LiteLLM → Anthropic → parsed response
  - Not covered: `Comcent.Deepgram` against a real alternate endpoint, and `embed_text`/embeddings through a non-OpenAI provider (Anthropic has no embeddings API, so this specific LiteLLM setup can't exercise that path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
