### PR TITLE
Fix 500 error for users not yet in an org

### DIFF
--- a/packages/web-app/src/routes/app/[subdomain]/+layout.server.ts
+++ b/packages/web-app/src/routes/app/[subdomain]/+layout.server.ts
@@ -12,11 +12,10 @@ export const load: LayoutServerLoad = async ({ cookies, params }) => {
     organizations: any[];
   }>(`/api/v2/${params.subdomain}/me/context`, user.idToken);
   if (!result.ok) {
-    // Server returns 303→/org when user isn't a member of this subdomain. The
-    // SSR fetch follows the redirect, which 404s because /org is a SvelteKit
-    // route (not a Phoenix route). Bounce the browser to /org so it can pick
-    // or create an org through the web-app.
-    if (result.status === 404 || result.status === 403 || result.status === 401) {
+    if (
+      result.status === 404 &&
+      (result.data as { error?: string } | null)?.error === 'not_org_member'
+    ) {
       throw redirect(303, '/org');
     }
     throw new Error(result.error);

--- a/server/lib/comcent_web/plugs/ensure_is_org_member.ex
+++ b/server/lib/comcent_web/plugs/ensure_is_org_member.ex
@@ -11,13 +11,21 @@ defmodule ComcentWeb.Plugs.EnsureIsOrgMember do
 
     case User.find_user_and_org(current_user.email, subdomain) do
       nil ->
-        conn
-        |> put_status(:see_other)
-        |> Phoenix.Controller.redirect(to: "/org")
-        |> halt()
+        not_org_member(conn)
 
       user ->
         assign(conn, :current_user, user)
     end
+  end
+
+  # This is called from SvelteKit's SSR `fetch`, which auto-follows redirects
+  # server-to-server, so it can't be a browser-facing `redirect(to: "/org")`
+  # here - that gets resolved against the API host and 404s. Return a
+  # structured error and let the frontend decide to navigate the browser.
+  defp not_org_member(conn) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(404, ~s({"error":"not_org_member"}))
+    |> halt()
   end
 end

--- a/server/lib/comcent_web/plugs/ensure_org_admin_member.ex
+++ b/server/lib/comcent_web/plugs/ensure_org_admin_member.ex
@@ -12,10 +12,7 @@ defmodule ComcentWeb.Plugs.EnsureOrgAdminMember do
 
     case User.find_user_and_org(current_user.email, subdomain) do
       nil ->
-        conn
-        |> put_status(:see_other)
-        |> Phoenix.Controller.redirect(to: "/org")
-        |> halt()
+        not_org_member(conn)
 
       user ->
         # Find the org member that matches the subdomain
@@ -26,21 +23,35 @@ defmodule ComcentWeb.Plugs.EnsureOrgAdminMember do
 
         case org_member do
           nil ->
-            conn
-            |> put_status(:see_other)
-            |> Phoenix.Controller.redirect(to: "/org")
-            |> halt()
+            not_org_member(conn)
 
           org_member ->
             if org_member.role != role do
-              conn
-              |> put_status(:see_other)
-              |> Phoenix.Controller.redirect(to: "/app/#{subdomain}")
-              |> halt()
+              insufficient_role(conn)
             else
               assign(conn, :current_user, user)
             end
         end
     end
+  end
+
+  # These are called from SvelteKit's SSR `fetch`, which auto-follows
+  # redirects server-to-server, so they can't be browser-facing
+  # `redirect(to: ...)` here - that gets resolved against the API host and
+  # 404s. Return a structured error and let the frontend decide to navigate
+  # the browser.
+  defp not_org_member(conn) do
+    json_error(conn, 404, "not_org_member")
+  end
+
+  defp insufficient_role(conn) do
+    json_error(conn, 403, "insufficient_role")
+  end
+
+  defp json_error(conn, status, error) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(status, ~s({"error":"#{error}"}))
+    |> halt()
   end
 end


### PR DESCRIPTION
## Summary
- `EnsureIsOrgMember`/`EnsureOrgAdminMember` redirected to `/org` when a user wasn't a member of the org for the current subdomain — but that redirect is only meaningful for a browser navigation
- SvelteKit's SSR `fetch` (server-to-server) auto-follows that redirect straight into the Phoenix API host, where `/org` isn't a route, producing a 404 that surfaced to the user as a generic 500
- The plugs now return a structured JSON error (`not_org_member` / `insufficient_role`) instead of a redirect, and `+layout.server.ts` reads that signal to issue the actual browser redirect itself
- Also narrows the previous catch-all (`404 || 403 || 401`) check down to the specific not-a-member case, so real auth/role failures aren't silently swallowed into a bogus "go create an org" redirect

## Test plan
- [x] `mix compile --warnings-as-errors` passes (ran automatically via pre-commit hook)
- [x] Reproduced end-to-end: signed up a new user, accepted the TOS, hit `/app/:subdomain` before joining an org — previously 500'd, now redirects cleanly to `/org`