### PR TITLE
Unregister SIP contacts whose fork branch fails to connect

### DIFF
--- a/sbc/proxy.go
+++ b/sbc/proxy.go
@@ -489,6 +489,12 @@ func (p *Proxy) handleInviteFromFSToUser(req *sip.Request, tx sip.ServerTransact
 		case r := <-results:
 			if r.err != nil {
 				pending--
+				// A branch that failed to connect (e.g. a closed WebSocket
+				// left behind by a stale browser tab) isn't coming back —
+				// drop it so future calls don't keep forking to a dead peer.
+				slog.Info("Fork branch failed; unregistering dead contact",
+					"aor", aor, "address", preps[r.idx].c.Address, "error", r.err)
+				p.reg.UnregisterContact(aor, preps[r.idx].c.Address)
 				continue
 			}
 			resp := r.resp


### PR DESCRIPTION
## Summary
- The SBC already forks inbound calls to every registered contact for a user and cancels the losers once one answers.
- What it didn't do: if a branch can't even connect (e.g. a closed WebSocket left behind by a stale browser tab), that dead contact stays registered and keeps getting forked to on every future call.
- Now a contact is unregistered as soon as its fork branch fails to connect.

## Test plan
- [x] `go build ./...` / `go vet ./...` pass in `sbc/`.