### PR TITLE
Redesign dialer widget UI + fix docker network subnet collision

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ DEV_IP=replaceMe # This is dev machine IP, used for local development
 # Comma-separated CIDRs added as ALLOW rules to FreeSWITCH's "private" ACL.
 # Anything matching is treated as local (rtp-ip used in SDP). Typically the
 # docker subnet that FS shares with the SBC and any local peers.
-# Example: 172.31.0.0/16
+# Example: 172.32.0.0/16
 FS_LOCAL_NETWORK=replaceMe
 DEV_RABBITMQ_USERNAME=replaceMe
 DEV_RABBITMQ_PASSWORD=replaceMe

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -188,10 +188,10 @@ services:
       - '6080:80/tcp'
     networks:
       comcent-network:
-        ipv4_address: 172.31.17.9
+        ipv4_address: 172.32.17.9
     environment:
       - SIP_USER_ROOT_DOMAIN=localhost
-      - PRIVATE_IP=172.31.17.9
+      - PRIVATE_IP=172.32.17.9
       - PUBLIC_IP=${DEV_IP}
       - PUBLIC_SIP_PORT=6060
       - INTERNAL_API_BASE_URL=http://server:4000/internal-api
@@ -217,9 +217,9 @@ services:
       - '6080:80/tcp'
     networks:
       comcent-network:
-        ipv4_address: 172.31.17.9
+        ipv4_address: 172.32.17.9
     environment:
-      - PRIVATE_IP=172.31.17.9
+      - PRIVATE_IP=172.32.17.9
       - PUBLIC_IP=${DEV_IP}
       - SIP_USER_ROOT_DOMAIN=localhost
       - INTERNAL_API_BASE_URL=http://server:4000/internal-api
@@ -275,14 +275,14 @@ services:
     # docker happens to hand out on each restart.
     networks:
       comcent-network:
-        ipv4_address: 172.31.0.11
+        ipv4_address: 172.32.0.11
 
 networks:
   comcent-network:
     driver: bridge
     ipam:
       config:
-        - subnet: 172.31.0.0/16
+        - subnet: 172.32.0.0/16
 
 volumes:
   postgres_data:

--- a/go/config.example.yml
+++ b/go/config.example.yml
@@ -13,8 +13,8 @@ network:
   publicIP: 192.168.31.23
 
 kamailio:
-  staticIP: 172.31.17.9
-  dockerIP: 172.31.17.9
+  staticIP: 172.32.17.9
+  dockerIP: 172.32.17.9
   localhostIP: 127.0.0.1
   port: 5060
 

--- a/go/config/config.go
+++ b/go/config/config.go
@@ -107,7 +107,7 @@ func GetConfig() *Config {
 					StaticIP    string `yaml:"staticIP"`
 					LocalhostIP string `yaml:"localhostIP"`
 					Port        int    `yaml:"port"`
-				}{StaticIP: "172.31.17.9", LocalhostIP: "127.0.0.1", Port: 5060},
+				}{StaticIP: "172.32.17.9", LocalhostIP: "127.0.0.1", Port: 5060},
 				LogLevel: "info",
 				Env:      "dev",
 				Calls: struct {

--- a/packages/web-app/src/lib/components/DialerWidget/CurrentCall.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/CurrentCall.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import H6 from '$lib/components/html/H6.svelte';
   import CallTime from '$lib/components/DialerWidget/CallTime.svelte';
   import HangupButton from '$lib/components/DialerWidget/buttons/HangupButton.svelte';
   import HoldButton from '$lib/components/DialerWidget/buttons/HoldButton.svelte';
@@ -11,6 +10,8 @@
   import TransferButton from '$lib/components/DialerWidget/buttons/TransferButton.svelte';
   import type { Session } from 'sip.js';
   import type { SessionManager } from 'sip.js/lib/platform/web';
+  import { isValidPhoneNumber } from 'libphonenumber-js';
+  import type { MemberSearchResult } from '$lib/server/types/MemberSearchResult';
 
   const dispatch = createEventDispatcher<{
     hangup: void;
@@ -23,12 +24,14 @@
     attendedTransfer: { transferAddress: string };
     confirmAttendedTransfer: void;
     cancelAttendedTransfer: void;
+    newCall: void;
   }>();
 
   export let sessionManager: SessionManager;
   export let startTime: Date | undefined;
   export let session: Session;
   export let heldForAttendedTransfer: Session | undefined | null;
+  export let search: ((text: string) => Promise<MemberSearchResult[]>) | undefined = undefined;
 
   let showDialPad = false;
 
@@ -66,7 +69,49 @@
   }
 
   let showTransferMenu = false;
+  let transferMode: 'blind' | 'attended' = 'blind';
   let transferAddress = '';
+  let transferSearchResults: MemberSearchResult[] = [];
+
+  function closeTransferMenu() {
+    showTransferMenu = false;
+    transferMode = 'blind';
+    transferAddress = '';
+    transferSearchResults = [];
+  }
+
+  async function onTransferAddressInput(e: Event) {
+    const value = (e.target as HTMLInputElement).value;
+    if (isValidPhoneNumber(value) || value.length < 3 || !search) {
+      transferSearchResults = [];
+      return;
+    }
+    transferSearchResults = await search(value);
+  }
+
+  function selectTransferMember(member: MemberSearchResult) {
+    transferAddress = member.username;
+    transferSearchResults = [];
+  }
+
+  function onConfirmTransfer() {
+    if (transferAddress === '') return;
+    const address = transferAddress;
+    closeTransferMenu();
+    if (transferMode === 'blind') {
+      dispatch('blindTransfer', { transferAddress: address });
+    } else {
+      dispatch('attendedTransfer', { transferAddress: address });
+    }
+  }
+
+  function callerLabel(s: Session) {
+    return s.remoteIdentity.friendlyName ?? s.remoteIdentity.uri;
+  }
+
+  function callerSub(s: Session) {
+    return s.remoteIdentity.friendlyName ? s.remoteIdentity.uri : '';
+  }
 
   onMount(() => {
     hold = sessionManager.isHeld(session);
@@ -74,123 +119,181 @@
   });
 </script>
 
-<div
-  class="p-4 mb-4 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
->
-  <div class="flex justify-between">
-    <div>
-      <H6>{session.remoteIdentity.friendlyName ?? session.remoteIdentity.uri}</H6>
-      <p class="mb-3 text-gray-500 dark:text-gray-400">
-        {session.remoteIdentity.friendlyName ? session.remoteIdentity.uri : ''}
-      </p>
+<div>
+  <div class="flex items-start justify-between gap-3">
+    <div class="min-w-0">
+      <h6 class="truncate text-base font-bold text-gray-900 dark:text-white">
+        {callerLabel(session)}
+      </h6>
+      {#if callerSub(session)}
+        <p class="truncate text-sm text-gray-500 dark:text-gray-400">{callerSub(session)}</p>
+      {/if}
     </div>
-    <div class="flex flex-col justify-center">
+    <div class="shrink-0 text-right">
       {#if startTime}
-        <CallTime {startTime} class="text-2xl mr-8" />
+        <div class="text-xs font-bold uppercase tracking-wide text-green-600 dark:text-green-400">
+          Connected
+        </div>
+        <CallTime {startTime} class="font-mono text-sm" />
       {:else}
-        <p class="text-gray-500 dark:text-gray-400">Connecting...</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400">Connecting...</p>
       {/if}
     </div>
   </div>
-  <div class="flex justify-between">
+
+  <div class="mt-3 flex gap-1.5">
     {#if startTime}
       <MuteButton bind:muted />
       {#if !heldForAttendedTransfer}
         <HoldButton bind:hold />
-        {#if !showTransferMenu}
-          <TransferButton
-            on:click={() => {
-              showTransferMenu = !showTransferMenu;
-            }}
-          />
-        {/if}
+        <TransferButton
+          active={showTransferMenu}
+          on:click={() => {
+            if (showTransferMenu) {
+              closeTransferMenu();
+            } else {
+              showTransferMenu = true;
+            }
+          }}
+        />
       {/if}
     {/if}
-    <HangupButton on:click={() => dispatch('hangup')} />
     <DialPadButton bind:showDialPad />
+    <HangupButton on:click={() => dispatch('hangup')} />
   </div>
+
+  {#if startTime && !heldForAttendedTransfer}
+    <button
+      type="button"
+      on:click={() => dispatch('newCall')}
+      class="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg border border-gray-300 py-2 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+    >
+      + New Call
+    </button>
+  {/if}
+
   {#if showTransferMenu}
-    <div transition:slide={{ delay: 250, duration: 300 }} class="mt-3">
-      <input
-        type="text"
-        id="toAddress"
-        class="bg-gray-50 mb-3 w-full border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 inline-block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-        bind:value={transferAddress}
-      />
-      <div class="flex justify-between">
+    <div
+      transition:slide={{ delay: 150, duration: 250 }}
+      class="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div class="mb-2 flex gap-2">
         <button
           type="button"
-          on:click={() => {
-            showTransferMenu = false;
-            dispatch('blindTransfer', { transferAddress });
-          }}
-          disabled={transferAddress === ''}
-          class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+          on:click={() => (transferMode = 'blind')}
+          class="flex-1 rounded-md border px-2 py-1.5 text-xs font-semibold transition-colors"
+          class:transfer-mode-active={transferMode === 'blind'}
+          class:transfer-mode-inactive={transferMode !== 'blind'}
         >
           Blind Transfer
         </button>
-
         <button
           type="button"
-          on:click={() => {
-            showTransferMenu = false;
-            dispatch('attendedTransfer', { transferAddress });
-          }}
-          disabled={transferAddress === ''}
-          class=" text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-blue-600 dark:hover:bg-blue-700 focus:outline-none dark:focus:ring-blue-800"
+          on:click={() => (transferMode = 'attended')}
+          class="flex-1 rounded-md border px-2 py-1.5 text-xs font-semibold transition-colors"
+          class:transfer-mode-active={transferMode === 'attended'}
+          class:transfer-mode-inactive={transferMode !== 'attended'}
         >
           Attended Transfer
         </button>
+      </div>
+      <p class="mb-2 text-xs text-gray-500 dark:text-gray-400">
+        {transferMode === 'blind'
+          ? 'Redirects the call immediately — you will be disconnected.'
+          : 'Rings the destination privately first; the customer stays on hold until you complete or cancel.'}
+      </p>
 
+      <div class="relative">
+        <input
+          type="text"
+          placeholder="Name or number"
+          class="w-full rounded-lg border border-gray-300 bg-white p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
+          bind:value={transferAddress}
+          on:input={onTransferAddressInput}
+        />
+        {#if transferSearchResults.length > 0}
+          <div
+            class="absolute z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-700"
+          >
+            <ul class="py-1 text-sm text-gray-700 dark:text-gray-200">
+              {#each transferSearchResults as member}
+                <li>
+                  <button
+                    type="button"
+                    on:click|preventDefault={() => selectTransferMember(member)}
+                    class="block w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    {member.username} [{member.presence}]
+                  </button>
+                </li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
+      </div>
+
+      <div class="mt-2 flex justify-end gap-2">
         <button
           type="button"
-          on:click={() => {
-            showTransferMenu = false;
-            transferAddress = '';
-          }}
-          class=" text-white bg-blue-700 hover:bg-red-800 focus:ring-4 focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 dark:bg-red-600 dark:hover:bg-red-700 focus:outline-none dark:focus:ring-blue-800"
+          on:click={closeTransferMenu}
+          class="rounded-lg px-3 py-2 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700"
         >
           Cancel
         </button>
+        <button
+          type="button"
+          on:click={onConfirmTransfer}
+          disabled={transferAddress === ''}
+          class="rounded-lg bg-blue-600 px-4 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-gray-300 dark:disabled:bg-gray-600"
+        >
+          {transferMode === 'blind' ? 'Transfer Call' : 'Call Privately'}
+        </button>
       </div>
     </div>
   {/if}
+
   {#if heldForAttendedTransfer}
-    <div transition:slide={{ delay: 250, duration: 300 }}>
-      <H6>
-        {heldForAttendedTransfer.remoteIdentity.friendlyName ??
-          heldForAttendedTransfer.remoteIdentity.uri}
-      </H6>
-      <p class="mb-3 text-gray-500 dark:text-gray-400">
-        {heldForAttendedTransfer.remoteIdentity.friendlyName
-          ? heldForAttendedTransfer.remoteIdentity.uri
-          : ''}
-      </p>
-      <div class="flex justify-between">
+    <div
+      transition:slide={{ delay: 150, duration: 250 }}
+      class="mt-3 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-950"
+    >
+      <div
+        class="mb-1 text-xs font-bold uppercase tracking-wide text-amber-700 dark:text-amber-300"
+      >
+        {callerLabel(session)} is on hold
+      </div>
+      <h6 class="text-sm font-bold text-gray-900 dark:text-white">
+        {callerLabel(heldForAttendedTransfer)}
+      </h6>
+      {#if callerSub(heldForAttendedTransfer)}
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          {callerSub(heldForAttendedTransfer)}
+        </p>
+      {/if}
+      <div class="mt-2 flex gap-2">
         <button
           type="button"
           on:click={onConfirmAttendedTransfer}
-          class=" ml-4 mr-1 text-white bg-orange-700 hover:bg-orange-800 focus:ring-4 focus:outline-none focus:ring-orange-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-orange-800"
+          class="flex-1 rounded-lg bg-blue-600 px-3 py-2 text-xs font-semibold text-white transition-colors hover:bg-blue-700"
         >
-          Transfer
+          Complete Transfer
         </button>
-
         <button
           type="button"
           on:click={onCancelAttendedTransfer}
-          class=" ml-4 mr-1 text-white bg-orange-700 hover:bg-orange-800 focus:ring-4 focus:outline-none focus:ring-orange-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-orange-600 dark:hover:bg-orange-700 dark:focus:ring-orange-800"
+          class="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-700"
         >
-          Cancel & Talk
+          Resume Call
         </button>
       </div>
     </div>
   {/if}
+
   {#if showDialPad}
-    <div transition:slide={{ delay: 250, duration: 300 }} class="mt-3">
+    <div transition:slide={{ delay: 150, duration: 250 }} class="mt-3">
       <input
         type="text"
-        id="toAddress"
-        class="bg-gray-50 mb-3 w-full border border-gray-300 text-gray-900 rounded-lg focus:ring-blue-500 focus:border-blue-500 inline-block p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+        class="mb-2 w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-center font-mono text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
         value={dtmfSentNumbers}
         disabled
       />
@@ -198,3 +301,12 @@
     </div>
   {/if}
 </div>
+
+<style lang="postcss">
+  .transfer-mode-active {
+    @apply border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950 dark:text-blue-300;
+  }
+  .transfer-mode-inactive {
+    @apply border-gray-300 bg-white text-gray-600 hover:bg-gray-100 dark:border-gray-600 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-700;
+  }
+</style>

--- a/packages/web-app/src/lib/components/DialerWidget/DialPad.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/DialPad.svelte
@@ -6,11 +6,11 @@
   const dialPadNumbers = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '*', '0', '#'];
 </script>
 
-<div class="grid grid-cols-3 gap-3">
+<div class="grid grid-cols-3 gap-2">
   {#each dialPadNumbers as number}
     <button
       type="button"
-      class="px-6 py-3.5 text-base font-medium text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+      class="rounded-lg bg-gray-100 py-3 text-base font-semibold text-gray-800 transition-colors hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-300 dark:bg-gray-800 dark:text-gray-100 dark:hover:bg-gray-700 dark:focus:ring-blue-800"
       on:click={() => dispatch('dialKeyPress', { number })}
     >
       {number}

--- a/packages/web-app/src/lib/components/DialerWidget/DialerWidget.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/DialerWidget.svelte
@@ -5,18 +5,17 @@
   import MinusIcon from '$lib/components/Icons/MinusIcon.svelte';
   import ExpandIcon from '$lib/components/Icons/ExpandIcon.svelte';
   import ClearLeftIcon from '$lib/components/Icons/ClearLeftIcon.svelte';
-  import KeyboardIcon from '$lib/components/Icons/KeyboardIcon.svelte';
   import PhoneIcon from '$lib/components/Icons/PhoneIcon.svelte';
   import { slide } from 'svelte/transition';
   import DialPad from './DialPad.svelte';
   import { onDestroy, onMount } from 'svelte';
   import type { Invitation } from 'sip.js';
   import RingNotification from '$lib/components/DialerWidget/RingNotification.svelte';
-  import PhoneDisconnectIcon from '$lib/components/Icons/PhoneDisconnectIcon.svelte';
   import { Session, UserAgent } from 'sip.js';
   import { SessionManager } from 'sip.js/lib/platform/web';
   import type { SessionManagerDelegate } from 'sip.js/lib/platform/web';
   import CurrentCall from '$lib/components/DialerWidget/CurrentCall.svelte';
+  import CallTime from '$lib/components/DialerWidget/CallTime.svelte';
   import { isValidPhoneNumber } from 'libphonenumber-js';
   import type { MemberSearchResult } from '$lib/server/types/MemberSearchResult';
   import Spinner from '../Icons/Spinner.svelte';
@@ -58,8 +57,19 @@
   let invitations: Invitation[] = [];
   export let currentCall: Session | null = null;
   let heldForAttendedTransfer: Session | null = null;
-  let callOnHoldStack: Session[] = [];
+  let heldCalls: { session: Session; heldSince: Date }[] = [];
   let startTimeForSession: Record<string, Date> = {};
+
+  // Incoming calls the agent has soft-dismissed (not SIP-rejected — just
+  // demoted out of the primary overlay into the "Also Waiting" list) until
+  // answered, declined, or the caller hangs up.
+  let ignoredInvitationIds: Set<string> = new Set();
+  $: primaryInvitation = invitations.find((i) => !ignoredInvitationIds.has(i.id)) ?? invitations[0];
+  $: waitingInvitations = invitations.filter((i) => i !== primaryInvitation);
+  // True when the primary card is itself an ignored call shown only because
+  // there's nothing else to promote — lets the UI show it's been silenced
+  // instead of looking unchanged and identical to a fresh, un-ignored call.
+  $: primaryIsIgnored = primaryInvitation ? ignoredInvitationIds.has(primaryInvitation.id) : false;
 
   let remoteAudio: HTMLAudioElement;
   let ringSound: HTMLAudioElement;
@@ -70,6 +80,10 @@
 
   let socket: Socket | undefined;
   let presenceChannel: any;
+
+  function sessionLabel(s: Session) {
+    return String(s.remoteIdentity.friendlyName ?? s.remoteIdentity.uri);
+  }
 
   async function searchUser(searchText: string) {
     try {
@@ -133,11 +147,13 @@
 
   function playRing() {
     ringSound.currentTime = 0;
-    ringSound.play();
+    ringSound.play().catch(() => {});
   }
 
   function stopRing() {
-    ringSound?.pause();
+    if (!ringSound) return;
+    ringSound.pause();
+    ringSound.currentTime = 0;
   }
 
   let onHangupCallbacks: any[] = [];
@@ -187,15 +203,27 @@
         callback();
       });
       delete startTimeForSession[session.id];
+      ignoredInvitationIds.delete(session.id);
+      ignoredInvitationIds = ignoredInvitationIds;
+
       if (currentCall === session) {
-        currentCall = null;
+        if (heldCalls.length > 0) {
+          // Resume the longest-parked call automatically, same as picking up
+          // the next line once the current one clears.
+          const [next, ...rest] = heldCalls;
+          heldCalls = rest;
+          sessionManager.unhold(next.session);
+          currentCall = next.session;
+        } else {
+          currentCall = null;
+        }
       } else {
-        // Remove either from invitations of from on hold stack
+        // Remove either from invitations or from the held-calls park stack.
         invitations = invitations.filter((i) => i !== session);
         if (invitations.length === 0) {
           stopRing();
         }
-        callOnHoldStack = callOnHoldStack.filter((i) => i !== session);
+        heldCalls = heldCalls.filter((h) => h.session !== session);
       }
 
       if (heldForAttendedTransfer === session) {
@@ -303,14 +331,67 @@
     socket?.disconnect();
   });
 
-  function onAnswer(event: CustomEvent<Invitation>) {
+  async function onAnswer(event: CustomEvent<Invitation>) {
     const invitation = event.detail;
-    invitation?.accept();
+    if (!invitation) return;
+    ignoredInvitationIds.delete(invitation.id);
+    ignoredInvitationIds = ignoredInvitationIds;
+    if (currentCall) {
+      await sessionManager.hold(currentCall);
+      heldCalls = [...heldCalls, { session: currentCall, heldSince: new Date() }];
+    }
+    // Go through SessionManager rather than the raw Invitation so its
+    // internal session bookkeeping/media setup runs (see the manual
+    // setupRemoteMedia patch in onAttendedTransferReject below, needed
+    // precisely because bypassing SessionManager skips that wiring).
+    await sessionManager.answer(invitation);
   }
 
   function onDecline(event: CustomEvent<Invitation>) {
     const invitation = event.detail;
-    invitation?.reject();
+    if (!invitation) return;
+    sessionManager.decline(invitation);
+  }
+
+  function onIgnore(event: CustomEvent<Invitation>) {
+    const invitation = event.detail;
+    if (!invitation) return;
+    ignoredInvitationIds.add(invitation.id);
+    ignoredInvitationIds = ignoredInvitationIds;
+    // Ignore silences the audible alert without touching the SIP session —
+    // the call keeps ringing on the network and stays visible (demoted into
+    // the waiting list), it just stops making noise.
+    stopRing();
+  }
+
+  async function resumeHeldCall(target: Session) {
+    if (currentCall) {
+      await sessionManager.hold(currentCall);
+      heldCalls = [...heldCalls, { session: currentCall, heldSince: new Date() }];
+    }
+    heldCalls = heldCalls.filter((h) => h.session !== target);
+    await sessionManager.unhold(target);
+    currentCall = target;
+  }
+
+  function dropHeldCall(session: Session) {
+    sessionManager.hangup(session);
+  }
+
+  // Explicit "start a new call" action rather than overloading Hold: parks
+  // the current call the same way answering a second incoming call does,
+  // then clears currentCall so the idle dial panel reappears to place the
+  // new outbound call.
+  async function onNewCall() {
+    if (!currentCall) return;
+    await sessionManager.hold(currentCall);
+    heldCalls = [...heldCalls, { session: currentCall, heldSince: new Date() }];
+    currentCall = null;
+  }
+
+  function onDtmf(event: CustomEvent<{ number: string }>) {
+    if (!currentCall) return;
+    sessionManager.sendDTMF(currentCall, event.detail.number);
   }
 
   export async function dial(fromNumber: number, toNumber: number) {
@@ -337,11 +418,10 @@
     if (!currentCall || !transferAddress) {
       return;
     }
-    console.log(`Blind transfer call to ${transferAddress}`);
     await sessionManager.transfer(currentCall, `sip:${transferAddress}@${domainName}`, {
       requestDelegate: {
         onAccept() {
-          console.log('Blind transfer accepted');
+          toast.success(`Call transferred to ${transferAddress}`);
           currentCall = null;
         },
       },
@@ -353,7 +433,6 @@
     if (!currentCall || !transferAddress) {
       return;
     }
-    console.log(`Attended transfer call to ${transferAddress}`);
     await sessionManager.hold(currentCall);
     heldForAttendedTransfer = currentCall;
     currentCall = await sessionManager.call(`sip:${transferAddress}@${domainName}`);
@@ -361,10 +440,11 @@
 
   async function onAttendedTransferComplete() {
     if (!heldForAttendedTransfer || !currentCall) return;
+    const transferredTo = sessionLabel(currentCall);
     await sessionManager.transfer(heldForAttendedTransfer, currentCall, {
       requestDelegate: {
         onAccept() {
-          console.log('Attended transfer accepted');
+          toast.success(`Call transferred to ${transferredTo}`);
           heldForAttendedTransfer = null;
           currentCall = null;
         },
@@ -425,11 +505,21 @@
 
   let availableStatus = ['Logged Out', 'Available', 'On Break', 'On Call', 'Wrap Up', 'Busy'];
   let status = 'Available';
+  let statusMenuOpen = false;
+  const statusDotColors: Record<string, string> = {
+    'Logged Out': 'bg-gray-400 dark:bg-gray-500',
+    Available: 'bg-green-500',
+    'On Break': 'bg-amber-500',
+    'On Call': 'bg-blue-500',
+    'Wrap Up': 'bg-purple-500',
+    Busy: 'bg-red-500',
+  };
 
-  $: showExpanded = expanded || !!currentCall;
+  $: showExpanded = expanded || !!currentCall || heldCalls.length > 0;
 
   function toggleExpanded() {
     expanded = !expanded;
+    statusMenuOpen = false;
   }
 
   // Drag/dock positioning. At rest the widget is pinned by whichever corner
@@ -559,9 +649,8 @@
     };
   }
 
-  async function onStatusChange(e: Event) {
-    const target = e.target as HTMLSelectElement;
-    const status = target.value;
+  async function selectStatus(newStatus: string) {
+    statusMenuOpen = false;
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -574,7 +663,7 @@
         {
           method: 'POST',
           headers,
-          body: JSON.stringify({ presence: status }),
+          body: JSON.stringify({ presence: newStatus }),
         },
       );
       if (!presenceResponse.ok)
@@ -649,173 +738,197 @@
       ? `${anchorX}: ${offsetX}px; ${anchorY}: ${offsetY}px;`
       : ''}
 >
-  {#each invitations as invitation}
-    <RingNotification bind:invitation on:answer={onAnswer} on:decline={onDecline} />
-  {/each}
-  {#if currentCall}
-    <CurrentCall
-      startTime={startTimeForSession[currentCall.id]}
-      {sessionManager}
-      session={currentCall}
-      {heldForAttendedTransfer}
-      on:hangup={onHangup}
-      on:mute={onMute}
-      on:unmute={onUnmute}
-      on:hold={onHold}
-      on:unhold={onUnhold}
-      on:blindTransfer={onBlindTransfer}
-      on:attendedTransfer={onAttendedTransfer}
-      on:confirmAttendedTransfer={onAttendedTransferComplete}
-      on:cancelAttendedTransfer={onAttendedTransferReject}
+  {#if primaryInvitation}
+    <RingNotification
+      primary={primaryInvitation}
+      waiting={waitingInvitations}
+      isIgnored={primaryIsIgnored}
+      currentCallerName={currentCall ? sessionLabel(currentCall) : undefined}
+      on:answer={onAnswer}
+      on:decline={onDecline}
+      on:ignore={onIgnore}
     />
   {/if}
-
   <div
-    class="bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700"
+    class="rounded-xl border border-gray-200 bg-white shadow-xl dark:border-gray-700 dark:bg-gray-900"
   >
     <div
-      class="flex justify-between bg-gray-950 py-3 px-5 cursor-move touch-none select-none"
+      class="flex items-center justify-between rounded-t-xl bg-gray-900 py-2.5 px-4 cursor-move touch-none select-none dark:bg-gray-950"
       on:pointerdown={onDragHandlePointerDown}
     >
-      <div class="text-gray-500 dark:text-gray-400">
+      <div class="relative">
         {#if uaStatus !== 'Registered'}
-          {uaStatus}
+          <span class="text-sm text-gray-400">{uaStatus}</span>
         {:else}
-          <select
-            id="countries"
-            bind:value={status}
-            on:change={onStatusChange}
-            class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-sm focus:ring-blue-500 focus:border-blue-500 p-1 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
+          <button
+            type="button"
+            on:click={() => (statusMenuOpen = !statusMenuOpen)}
+            class="flex items-center gap-2 rounded-lg border border-gray-700 bg-gray-800 px-2.5 py-1.5 text-sm font-medium text-gray-100 hover:bg-gray-700"
           >
-            {#each availableStatus as s}
-              <option value={s}>{s}</option>
-            {/each}
-          </select>
+            <span class="h-2 w-2 rounded-full {statusDotColors[status] ?? 'bg-gray-400'}" />
+            {status}
+            <svg
+              class="h-3 w-3 text-gray-400"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M6 9l6 6 6-6" />
+            </svg>
+          </button>
+          {#if statusMenuOpen}
+            <div
+              class="absolute left-0 top-full z-10 mt-1 w-44 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+            >
+              {#each availableStatus as s}
+                <button
+                  type="button"
+                  on:click={() => selectStatus(s)}
+                  class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                >
+                  <span class="h-2 w-2 rounded-full {statusDotColors[s] ?? 'bg-gray-400'}" />
+                  {s}
+                </button>
+              {/each}
+            </div>
+          {/if}
         {/if}
       </div>
-      {#if expanded}
-        <button
-          on:click={toggleExpanded}
-          class="w-6 p-0 text-blue-700 hover:bg-gray-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm text-center inline-flex items-center dark:border-blue-500 dark:text-blue-500 dark:hover:text-white dark:focus:ring-blue-800 dark:hover:bg-gray-500"
-        >
+      <button
+        on:click={toggleExpanded}
+        class="rounded-md p-1 text-gray-400 hover:bg-gray-800 hover:text-white"
+      >
+        {#if expanded}
           <MinusIcon />
-        </button>
-      {:else}
-        <button
-          on:click={toggleExpanded}
-          class="w-6 p-0 text-blue-700 hover:bg-gray-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm text-center inline-flex items-center dark:border-blue-500 dark:text-blue-500 dark:hover:text-white dark:focus:ring-blue-800 dark:hover:bg-gray-500"
-        >
+        {:else}
           <ExpandIcon />
-        </button>
-      {/if}
+        {/if}
+        <span class="sr-only">{expanded ? 'Minimize' : 'Expand'}</span>
+      </button>
     </div>
     {#if showExpanded}
       <div class="p-3 relative" transition:slide={{ duration: 200 }}>
         {#if errorMessage}
-          <p class="text-red-500 text-sm mb-2">{errorMessage}</p>
+          <p class="mb-2 text-sm text-red-500">{errorMessage}</p>
         {/if}
-        <div>
-          <label
-            for="countries"
-            class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
-          >
-            Outbound Number
-          </label>
-          <div class="relative">
-            <input
-              autocomplete="off"
-              type="text"
-              id="name"
-              name="name"
-              class="cursor-default bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 pr-10 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-              placeholder="Search.."
-              required
-              bind:value={selectedOutboundInfo}
-              on:input={fetchNumbers}
-              on:click={showOrHideNumbers}
-            />
-            <svg
-              class="absolute inset-y-0 right-0 mr-3 mt-3 w-4 h-4 text-gray-800 dark:text-gray-400"
-              aria-hidden="true"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M19 9l-7 7-7-7"
-              />
-            </svg>
-          </div>
 
-          {#if showNumbers}
+        {#if heldCalls.length > 0}
+          <div class="mb-3">
             <div
-              class="absolute bottom-[7.3rem] w-[22rem] z-10 mb-2 bg-white divide-y divide-gray-100 rounded-lg shadow dark:bg-gray-700 max-h-64 overflow-y-auto"
+              class="mb-2 text-xs font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400"
             >
-              <ul
-                class="py-2 text-sm text-gray-700 dark:text-gray-200"
-                aria-labelledby="dropdownDefaultButton"
+              On Hold ({heldCalls.length})
+            </div>
+            <div class="flex flex-col gap-1.5">
+              {#each heldCalls as h (h.session.id)}
+                <div
+                  class="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-2.5 py-1.5 dark:border-amber-900 dark:bg-amber-950"
+                >
+                  <div class="min-w-0 flex-1">
+                    <div class="truncate text-sm font-medium text-gray-800 dark:text-gray-100">
+                      {h.session.remoteIdentity.friendlyName ?? h.session.remoteIdentity.uri}
+                    </div>
+                    <div class="flex items-center gap-1 text-xs text-amber-700 dark:text-amber-300">
+                      <span>On hold</span>
+                      <span>·</span>
+                      <CallTime startTime={h.heldSince} class="text-xs" />
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    on:click={() => resumeHeldCall(h.session)}
+                    class="whitespace-nowrap rounded-md bg-blue-600 px-2.5 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-blue-700"
+                  >
+                    Resume
+                  </button>
+                  <button
+                    type="button"
+                    on:click={() => dropHeldCall(h.session)}
+                    class="whitespace-nowrap rounded-md border border-gray-300 px-2 py-1.5 text-xs text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+                  >
+                    End
+                  </button>
+                </div>
+              {/each}
+            </div>
+          </div>
+        {/if}
+
+        {#if currentCall}
+          <CurrentCall
+            startTime={startTimeForSession[currentCall.id]}
+            {sessionManager}
+            session={currentCall}
+            {heldForAttendedTransfer}
+            search={searchUser}
+            on:hangup={onHangup}
+            on:mute={onMute}
+            on:unmute={onUnmute}
+            on:hold={onHold}
+            on:unhold={onUnhold}
+            on:blindTransfer={onBlindTransfer}
+            on:attendedTransfer={onAttendedTransfer}
+            on:confirmAttendedTransfer={onAttendedTransferComplete}
+            on:cancelAttendedTransfer={onAttendedTransferReject}
+            on:newCall={onNewCall}
+            on:dtmfNumberPress={onDtmf}
+          />
+        {:else}
+          <div>
+            <label
+              for="outboundNumber"
+              class="mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+            >
+              Outbound Number
+            </label>
+            <div class="relative">
+              <input
+                autocomplete="off"
+                type="text"
+                id="outboundNumber"
+                name="outboundNumber"
+                class="w-full cursor-default rounded-lg border border-gray-300 bg-gray-50 p-2.5 pr-9 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+                placeholder="Search.."
+                required
+                bind:value={selectedOutboundInfo}
+                on:input={fetchNumbers}
+                on:click={showOrHideNumbers}
+              />
+              <svg
+                class="absolute inset-y-0 right-0 mr-3 mt-3 h-4 w-4 text-gray-500 dark:text-gray-400"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
               >
-                {#each filteredNumbers as number}
-                  <li>
-                    <button
-                      on:click|preventDefault={() => selectNumber(number)}
-                      class="w-full block px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white text-left"
-                    >
-                      <div class="flex-1 min-w-0">
-                        <p class="text-sm font-medium text-gray-900 truncate dark:text-white">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M19 9l-7 7-7-7"
+                />
+              </svg>
+            </div>
+
+            {#if showNumbers}
+              <div
+                class="absolute bottom-[7.3rem] z-10 mb-2 w-[22rem] divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white shadow-lg dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800 max-h-64 overflow-y-auto"
+              >
+                <ul class="py-2 text-sm text-gray-700 dark:text-gray-200">
+                  {#each filteredNumbers as number}
+                    <li>
+                      <button
+                        on:click|preventDefault={() => selectNumber(number)}
+                        class="block w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                      >
+                        <p class="truncate text-sm font-medium text-gray-900 dark:text-white">
                           {number.name}
                           {number.number}
                         </p>
-                      </div>
-                    </button>
-                  </li>
-                {/each}
-              </ul>
-            </div>
-          {/if}
-        </div>
-        <div class="flex justify-between items-center">
-          <div class="relative">
-            <label
-              for="countries"
-              class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
-            >
-              Recipient
-            </label>
-            <input
-              autocomplete="off"
-              type="text"
-              id="destination"
-              name=""
-              class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-              placeholder="Destination number"
-              required
-              bind:value={toAddress}
-              on:input={fetchSuggestions}
-            />
-            {#if searchResults.length > 0}
-              <div
-                class="absolute bottom-full mb-2 z-10 bg-white divide-y divide-gray-100 rounded-lg shadow w-auto min-w-full dark:bg-gray-700"
-              >
-                <ul
-                  class="py-2 text-sm text-gray-700 dark:text-gray-200"
-                  aria-labelledby="dropdownDefaultButton"
-                >
-                  {#each searchResults as member}
-                    <li>
-                      <button
-                        on:click|preventDefault={() => selectUser(member)}
-                        class="w-full block px-2 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 dark:hover:text-white text-left"
-                      >
-                        <div class="flex-1 min-w-0">
-                          <p class="text-sm font-medium text-gray-900 truncate dark:text-white">
-                            {member.username} [{member.presence}]
-                          </p>
-                        </div>
                       </button>
                     </li>
                   {/each}
@@ -823,30 +936,60 @@
               </div>
             {/if}
           </div>
-          <button
-            type="button"
-            on:click={() => (toAddress = '')}
-            class="rounded-full mr-1 mt-6 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-          >
-            <ClearLeftIcon />
-            <span class="sr-only">Clear</span>
-          </button>
-
-          {#if currentCall}
+          <div class="mt-3 flex items-end justify-between gap-2">
+            <div class="relative flex-1">
+              <label
+                for="destination"
+                class="mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+              >
+                Recipient
+              </label>
+              <input
+                autocomplete="off"
+                type="text"
+                id="destination"
+                name="destination"
+                class="w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 font-mono text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+                placeholder="Destination number"
+                required
+                bind:value={toAddress}
+                on:input={fetchSuggestions}
+              />
+              {#if searchResults.length > 0}
+                <div
+                  class="absolute bottom-full z-10 mb-2 w-auto min-w-full divide-y divide-gray-100 rounded-lg border border-gray-200 bg-white shadow-lg dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800"
+                >
+                  <ul class="py-2 text-sm text-gray-700 dark:text-gray-200">
+                    {#each searchResults as member}
+                      <li>
+                        <button
+                          on:click|preventDefault={() => selectUser(member)}
+                          class="block w-full px-3 py-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                        >
+                          <p class="truncate text-sm font-medium text-gray-900 dark:text-white">
+                            {member.username} [{member.presence}]
+                          </p>
+                        </button>
+                      </li>
+                    {/each}
+                  </ul>
+                </div>
+              {/if}
+            </div>
             <button
               type="button"
-              on:click={onHangup}
-              class="rounded-full text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800 mr-1 mt-6 w-9 h-9"
+              on:click={() => (toAddress = '')}
+              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-800"
             >
-              <PhoneDisconnectIcon />
-              <span class="sr-only">Hangup</span>
+              <ClearLeftIcon />
+              <span class="sr-only">Clear</span>
             </button>
-          {:else}
+
             <button
               type="button"
               on:click={onDial}
               disabled={isDialing}
-              class="rounded-full mr-1 mt-6 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800 w-9 h-9"
+              class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 disabled:opacity-60 dark:focus:ring-blue-800"
             >
               {#if isDialing}
                 <Spinner className="ml-2" />
@@ -855,26 +998,26 @@
               {/if}
               <span class="sr-only">Dial</span>
             </button>
-          {/if}
+          </div>
 
           <button
             type="button"
             on:click={() => (showDialPad = !showDialPad)}
-            class=" rounded-full mt-6 text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+            class="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg border border-gray-300 py-2 text-xs font-semibold text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
           >
-            <KeyboardIcon />
-            <span class="sr-only">Show/Hide Keypad</span>
+            {showDialPad ? 'Hide Dial Pad' : 'Show Dial Pad'}
+            <span class="text-[10px]">{showDialPad ? '▲' : '▼'}</span>
           </button>
-        </div>
-        {#if showDialPad}
-          <div transition:slide={{ delay: 250, duration: 300 }} class="mt-2">
-            <DialPad
-              on:dialKeyPress={(e) => {
-                if (!toAddress) toAddress = '';
-                toAddress += e.detail.number;
-              }}
-            />
-          </div>
+          {#if showDialPad}
+            <div transition:slide={{ delay: 250, duration: 300 }} class="mt-3">
+              <DialPad
+                on:dialKeyPress={(e) => {
+                  if (!toAddress) toAddress = '';
+                  toAddress += e.detail.number;
+                }}
+              />
+            </div>
+          {/if}
         {/if}
       </div>
     {/if}

--- a/packages/web-app/src/lib/components/DialerWidget/RingNotification.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/RingNotification.svelte
@@ -1,67 +1,160 @@
 <script lang="ts">
-  import PhoneDisconnectIcon from '$lib/components/Icons/PhoneDisconnectIcon.svelte';
-  import PhoneIcon from '$lib/components/Icons/PhoneIcon.svelte';
   import { createEventDispatcher } from 'svelte';
   import type { Invitation } from 'sip.js';
 
-  export let invitation: Invitation;
+  export let primary: Invitation;
+  export let waiting: Invitation[] = [];
+  export let isIgnored = false;
+  export let currentCallerName: string | undefined = undefined;
 
   const dispatch = createEventDispatcher();
 
-  function onAnswer() {
+  function onAnswer(invitation: Invitation) {
     dispatch('answer', invitation);
   }
 
-  function onDecline() {
+  function onDecline(invitation: Invitation) {
     dispatch('decline', invitation);
   }
 
-  let viaNumber = '';
-  $: {
+  function onIgnore(invitation: Invitation) {
+    dispatch('ignore', invitation);
+  }
+
+  function displayName(invitation: Invitation) {
+    return invitation.remoteIdentity.displayName || invitation.remoteIdentity.uri.aor;
+  }
+
+  function subAddress(invitation: Invitation) {
+    return invitation.remoteIdentity.displayName ? invitation.remoteIdentity.uri.aor : '';
+  }
+
+  function viaNumber(invitation: Invitation) {
     const inboundInfo = invitation.request.headers['X-Inbound-Info']?.[0]?.raw;
     const firstPath = inboundInfo?.split('|')?.[0];
     const number = firstPath?.split(':')?.[1];
     const name = firstPath?.split(':')?.[2];
-    if (name && number) {
-      viaNumber = `${name} (${number})`;
-    }
+    return name && number ? `${name} (${number})` : '';
   }
 </script>
 
 <div
-  class="p-4 mb-4 bg-white border border-gray-200 rounded-lg shadow hover:bg-gray-100 dark:bg-gray-800 dark:border-gray-700 dark:hover:bg-gray-700"
+  class="mb-4 overflow-hidden rounded-2xl border bg-white shadow-lg dark:bg-gray-900 {isIgnored
+    ? 'border-gray-200 dark:border-gray-700'
+    : 'border-red-200 dark:border-red-900'}"
 >
-  <div class="flex items-center justify-between">
-    <div>
-      <h6 class="text-lg font-bold dark:text-white">
-        {invitation.remoteIdentity.displayName || invitation.remoteIdentity.uri.aor}
-      </h6>
-      {#if invitation.remoteIdentity.displayName}
-        <p class="mb-3 text-gray-500 dark:text-gray-400">{invitation.remoteIdentity.uri.aor}</p>
+  <div
+    class="flex items-center gap-2 px-3.5 py-2.5 {isIgnored
+      ? 'bg-gray-100 dark:bg-gray-800'
+      : 'bg-red-50 dark:bg-red-950'}"
+  >
+    <span class="h-2 w-2 rounded-full {isIgnored ? 'bg-gray-400' : 'bg-red-500 dark:bg-red-400'}" />
+    <span
+      class="text-xs font-bold uppercase tracking-wide {isIgnored
+        ? 'text-gray-500 dark:text-gray-400'
+        : 'text-red-700 dark:text-red-300'}"
+    >
+      {#if isIgnored}
+        Silenced — still ringing
+      {:else if waiting.length > 0}
+        Incoming Call — {waiting.length} more waiting
+      {:else}
+        Incoming Call
       {/if}
+    </span>
+  </div>
 
-      {#if viaNumber}
-        <p class="text-gray-500 dark:text-gray-400 font-bold">Inbound Number</p>
-        <p class="mb-3 text-gray-500 dark:text-gray-400">{viaNumber}</p>
+  <div class="p-4">
+    <div class="min-w-0">
+      <h6 class="truncate text-lg font-bold text-gray-900 dark:text-white">
+        {displayName(primary)}
+      </h6>
+      {#if subAddress(primary)}
+        <p class="truncate text-sm text-gray-500 dark:text-gray-400">{subAddress(primary)}</p>
+      {/if}
+      {#if viaNumber(primary)}
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          <span class="font-semibold">Inbound Number:</span>
+          {viaNumber(primary)}
+        </p>
       {/if}
     </div>
-    <div>
+
+    {#if currentCallerName}
+      <div
+        class="mt-3 rounded-lg bg-blue-50 px-3 py-2 text-xs text-blue-800 dark:bg-blue-950 dark:text-blue-200"
+      >
+        Answering will place <span class="font-semibold">{currentCallerName}</span>
+        on hold.
+      </div>
+    {/if}
+
+    <div class="mt-4 flex gap-2">
       <button
         type="button"
-        on:click={onAnswer}
-        class="mr-4 rounded-full text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium text-sm p-4 inline-flex justify-center items-center dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800"
+        on:click={() => onAnswer(primary)}
+        class="flex-1 rounded-lg bg-green-600 py-2.5 text-sm font-bold text-white transition-colors hover:bg-green-700 focus:outline-none focus:ring-4 focus:ring-green-300 dark:focus:ring-green-800"
       >
-        <PhoneIcon />
-        <span class="sr-only">Answer</span>
+        Answer
       </button>
       <button
         type="button"
-        on:click={onDecline}
-        class=" rounded-full text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium text-sm p-4 inline-flex justify-center items-center dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-red-800"
+        on:click={() => onDecline(primary)}
+        class="flex-1 rounded-lg bg-red-600 py-2.5 text-sm font-bold text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-4 focus:ring-red-300 dark:focus:ring-red-800"
       >
-        <PhoneDisconnectIcon />
-        <span class="sr-only">Decline</span>
+        Decline
       </button>
+      {#if !isIgnored}
+        <button
+          type="button"
+          on:click={() => onIgnore(primary)}
+          class="rounded-lg border border-gray-300 px-4 py-2.5 text-sm font-semibold text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Ignore
+        </button>
+      {/if}
     </div>
+
+    {#if waiting.length > 0}
+      <div class="mt-3 border-t border-red-100 pt-3 dark:border-red-900/40">
+        <div
+          class="mb-2 text-xs font-bold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+        >
+          Also Waiting
+        </div>
+        <div class="flex flex-col gap-1.5">
+          {#each waiting as invitation (invitation.id)}
+            <div
+              class="flex items-center gap-2 rounded-lg border border-gray-200 bg-gray-50 px-2.5 py-1.5 dark:border-gray-700 dark:bg-gray-800"
+            >
+              <div class="min-w-0 flex-1">
+                <div class="truncate text-sm font-medium text-gray-800 dark:text-gray-100">
+                  {displayName(invitation)}
+                </div>
+                {#if subAddress(invitation) || viaNumber(invitation)}
+                  <div class="truncate text-xs text-gray-500 dark:text-gray-400">
+                    {subAddress(invitation) || viaNumber(invitation)}
+                  </div>
+                {/if}
+              </div>
+              <button
+                type="button"
+                on:click={() => onAnswer(invitation)}
+                class="whitespace-nowrap rounded-md bg-green-600 px-2.5 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-green-700"
+              >
+                Answer
+              </button>
+              <button
+                type="button"
+                on:click={() => onDecline(invitation)}
+                class="whitespace-nowrap rounded-md border border-gray-300 px-2 py-1.5 text-xs text-gray-600 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                Decline
+              </button>
+            </div>
+          {/each}
+        </div>
+      </div>
+    {/if}
   </div>
 </div>

--- a/packages/web-app/src/lib/components/DialerWidget/buttons/DialPadButton.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/buttons/DialPadButton.svelte
@@ -1,27 +1,22 @@
 <script>
-  import KeyboardIcon from '$lib/components/Icons/KeyboardIcon.svelte';
-
   export let showDialPad = false;
 </script>
 
 <button
   type="button"
   on:click={() => (showDialPad = !showDialPad)}
-  class="rounded-full mr-1 text-white focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:focus:ring-blue-800"
+  class="flex-1 rounded-lg border py-2 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-800"
   class:active={showDialPad}
   class:inactive={!showDialPad}
 >
-  <KeyboardIcon />
-  <span class="sr-only">
-    {#if showDialPad}Hide{:else}Show{/if} Dial Pad
-  </span>
+  Keypad
 </button>
 
 <style lang="postcss">
   .active {
-    @apply bg-blue-700 hover:bg-blue-800 dark:bg-blue-600 dark:hover:bg-blue-700;
+    @apply border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950 dark:text-blue-300;
   }
   .inactive {
-    @apply bg-gray-400 hover:bg-gray-500 dark:bg-gray-400 dark:hover:bg-gray-500;
+    @apply border-gray-200 bg-white text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800;
   }
 </style>

--- a/packages/web-app/src/lib/components/DialerWidget/buttons/HangupButton.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/buttons/HangupButton.svelte
@@ -1,12 +1,7 @@
-<script>
-  import PhoneDisconnectIcon from '$lib/components/Icons/PhoneDisconnectIcon.svelte';
-</script>
-
 <button
   type="button"
   on:click
-  class="rounded-full mr-1 text-white bg-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-red-600 dark:hover:bg-red-700 dark:focus:ring-blue-800"
+  class="flex-1 rounded-lg border border-transparent bg-red-600 py-2 text-xs font-semibold text-white transition-colors hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-300 dark:focus:ring-red-800"
 >
-  <PhoneDisconnectIcon />
-  <span class="sr-only">Hangup</span>
+  End
 </button>

--- a/packages/web-app/src/lib/components/DialerWidget/buttons/HoldButton.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/buttons/HoldButton.svelte
@@ -1,31 +1,22 @@
 <script>
-  import PauseIcon from '$lib/components/Icons/PauseIcon.svelte';
-
   export let hold = false;
 </script>
 
 <button
   type="button"
   on:click={() => (hold = !hold)}
-  class="rounded-full mr-1 text-white focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:focus:ring-blue-800"
+  class="flex-1 rounded-lg border py-2 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-800"
   class:active={hold}
   class:inactive={!hold}
 >
-  <PauseIcon />
-  <span class="sr-only">
-    {#if hold}
-      Un hold
-    {:else}
-      Hold
-    {/if}
-  </span>
+  {hold ? 'Unhold' : 'Hold'}
 </button>
 
 <style lang="postcss">
   .active {
-    @apply bg-blue-700 hover:bg-blue-800 dark:bg-blue-600 dark:hover:bg-blue-700;
+    @apply border-amber-500 bg-amber-50 text-amber-700 dark:border-amber-500 dark:bg-amber-950 dark:text-amber-300;
   }
   .inactive {
-    @apply bg-gray-400 hover:bg-gray-500 dark:bg-gray-400 dark:hover:bg-gray-500;
+    @apply border-gray-200 bg-white text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800;
   }
 </style>

--- a/packages/web-app/src/lib/components/DialerWidget/buttons/MuteButton.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/buttons/MuteButton.svelte
@@ -1,27 +1,22 @@
 <script>
-  import MuteIcon from '$lib/components/Icons/MuteIcon.svelte';
-
   export let muted = false;
 </script>
 
 <button
   type="button"
   on:click={() => (muted = !muted)}
-  class="rounded-full mr-1 text-white focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:focus:ring-blue-800"
+  class="flex-1 rounded-lg border py-2 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-800"
   class:active={muted}
   class:inactive={!muted}
 >
-  <MuteIcon />
-  <span class="sr-only">
-    {#if muted}Unmute{:else}Mute{/if}
-  </span>
+  {muted ? 'Unmute' : 'Mute'}
 </button>
 
 <style lang="postcss">
   .active {
-    @apply bg-blue-700 hover:bg-blue-800 dark:bg-blue-600 dark:hover:bg-blue-700;
+    @apply border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950 dark:text-blue-300;
   }
   .inactive {
-    @apply bg-gray-400 hover:bg-gray-500 dark:bg-gray-400 dark:hover:bg-gray-500;
+    @apply border-gray-200 bg-white text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800;
   }
 </style>

--- a/packages/web-app/src/lib/components/DialerWidget/buttons/TransferButton.svelte
+++ b/packages/web-app/src/lib/components/DialerWidget/buttons/TransferButton.svelte
@@ -1,12 +1,22 @@
 <script>
-  import ShuffleIcon from '$lib/components/Icons/ShuffleIcon.svelte';
+  export let active = false;
 </script>
 
 <button
   type="button"
   on:click
-  class="rounded-full mr-1 text-white bg-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium text-sm p-2.5 inline-flex justify-center items-center dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-blue-800"
+  class="flex-1 rounded-lg border py-2 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-blue-300 dark:focus:ring-blue-800"
+  class:active
+  class:inactive={!active}
 >
-  <ShuffleIcon />
-  <span class="sr-only">Transfer</span>
+  Transfer
 </button>
+
+<style lang="postcss">
+  .active {
+    @apply border-blue-600 bg-blue-50 text-blue-700 dark:border-blue-500 dark:bg-blue-950 dark:text-blue-300;
+  }
+  .inactive {
+    @apply border-gray-200 bg-white text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Redesigns the web dialer widget: dark + light themed card, a single unified card body across idle/outgoing/active states (instead of stacked panels), a restyled incoming-call card, and a minimized pill state
- Adds a real multi-call hold/park flow: answering a second call now holds and parks the current one instead of clobbering it; an explicit "New Call" action holds the current call to free the line for a new outbound dial
- Fixes answer/decline to go through `SessionManager` instead of the raw `Invitation` object — declined calls weren't hanging up properly on the caller's end before this
- Wires DTMF keypad presses during a call to `SessionManager.sendDTMF` (previously a no-op)
- Adds a soft "Ignore" on incoming calls that silences the ring without rejecting the call over SIP
- Adds live member-search autocomplete to the call transfer address field
- Fixes `docker-compose.yaml`'s bridge network subnet (`172.31.0.0/16`), which collides with other common local docker-compose setups using the same default and causes a "Pool overlaps" error on `docker compose up`. Moved to `172.32.0.0/16`, updated consistently across the `sbc`/`kamailio`/`freeswitch` static IPs, the Go SBC's config fallback/example, and `.env.example`

## Test plan
- [x] Manual testing against a local docker-compose stack: idle → dial → outgoing → active
- [x] Incoming call while idle (answer / decline / ignore)
- [x] Incoming call while on an active call → answer → original call held → resume
- [x] Verified `docker compose up` no longer fails with a network pool overlap
- [x] `npm run check` (svelte-check) — no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)