### PR TITLE
Format only staged Elixir files on commit, not the whole tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,16 @@
     "docker:db:migrate": "docker compose exec -w /app server mix ecto.migrate",
     "docker:populate-country-state": "docker compose exec -w /code/packages/tools/ comcent-all-in-one node populate_country_state.js",
     "docker:web-app:build": "docker run --workdir /code -v \"$(pwd)\":/code node:20.11.1 sh -c \"npm i && npm run build\"\n",
-    "check:elixir": "cd server && mix format && mix compile --warnings-as-errors && cd ..",
+    "check:elixir": "cd server && mix compile --warnings-as-errors && cd ..",
     "install:rollup-platform": "./tools/install-rollup-platform.sh"
   },
   "lint-staged": {
     "*.{js,ts,html,css,vue,svelte}": [
       "npm run eslint-fix",
       "npm run stage-format"
+    ],
+    "server/**/*.{ex,exs}": [
+      "./tools/format-elixir-staged.sh"
     ]
   },
   "repository": {

--- a/tools/format-elixir-staged.sh
+++ b/tools/format-elixir-staged.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Formats only the staged Elixir files passed in as arguments (invoked by
+# lint-staged with absolute paths). Runs from server/ so mix picks up
+# server/.formatter.exs and server/mix.exs. lint-staged re-stages whatever
+# this script modifies, so formatting fixes never end up as a dangling
+# unstaged diff, and files outside this commit are never touched.
+
+set -e
+
+cd "$(dirname "$0")/../server"
+mix format "$@"


### PR DESCRIPTION
## Summary
- The pre-commit hook ran `mix format` across the entire `server/` tree on every commit, which silently reformatted unrelated files and left them as dangling unstaged changes after every commit.
- Adds a `tools/format-elixir-staged.sh` script wired into `lint-staged` so only the staged `.ex`/`.exs` files get formatted, and lint-staged re-stages whatever it fixes — no more dangling diffs.
- `check:elixir` no longer runs `mix format` itself (formatting now happens via lint-staged before this step runs), just `mix compile --warnings-as-errors`.

## Test plan
- [x] `mix compile --warnings-as-errors` still passes
- [x] Committing with a staged `.ex`/`.exs` file only formats that file, leaving the rest of the tree untouched