### PR TITLE
Apply mix format to two files with lingering formatting drift

### DIFF
--- a/server/config/runtime.exs
+++ b/server/config/runtime.exs
@@ -87,8 +87,7 @@ end
 # Base URL is separate from the key check above — self-hosters can point
 # this at any OpenAI-API-compatible endpoint (e.g. a self-hosted LiteLLM
 # proxy) instead of OpenAI directly, even without changing the key.
-config :comcent, :openai,
-  base_url: System.get_env("OPENAI_BASE_URL", "https://api.openai.com")
+config :comcent, :openai, base_url: System.get_env("OPENAI_BASE_URL", "https://api.openai.com")
 
 # ## Using releases
 #

--- a/server/lib/comcent_web/controllers/member_controller.ex
+++ b/server/lib/comcent_web/controllers/member_controller.ex
@@ -360,5 +360,4 @@ defmodule ComcentWeb.MemberController do
     )
     |> Repo.one()
   end
-
 end


### PR DESCRIPTION
## Summary
`server/config/runtime.exs` and `server/lib/comcent_web/controllers/member_controller.ex` had local edits that predated the lint-staged auto-format-on-commit hook (added in eaed23d) and were never run through it, so they'd drifted out of sync with `mix format`. This just runs the formatter — no behavior change.

## Test plan
- [x] `mix format --check-formatted` passes
- [x] `mix compile --warnings-as-errors` passes