### PR TITLE
Fix vCon transfer dialog original/target_dialog to use final array indices

### DIFF
--- a/server/lib/comcent/vcon.ex
+++ b/server/lib/comcent/vcon.ex
@@ -295,14 +295,21 @@ defmodule Comcent.VCon do
                 transferee = List.first(prev_dialog.parties -- [transferor])
                 transfer_target = List.first(next_dialog.parties -- prev_dialog.parties)
 
+                # prev_dialog is always the last element already in acc, and
+                # next_dialog will land right after the transfer object we're
+                # about to append, so these are the two dialogs' real indices
+                # in the final merged array, not their positions in temp_dialog.
+                original_index = length(acc) - 1
+                target_dialog_index = length(acc) + 1
+
                 transfer_dialog = %{
                   type: :transfer,
                   start: next_dialog.start,
                   transferor: transferor,
                   transferee: transferee,
                   transfer_target: transfer_target,
-                  original: i - 1,
-                  target_dialog: i
+                  original: original_index,
+                  target_dialog: target_dialog_index
                 }
 
                 acc ++ [transfer_dialog, next_dialog]


### PR DESCRIPTION
## Summary
- `original`/`target_dialog` on synthesized `"transfer"` Dialog Objects were computed from the index into `temp_dialog` (the flat list of per-leg recording dialogs, before transfer objects get spliced in), instead of the index into the final merged `dialog` array the [vCon spec](https://www.ietf.org/archive/id/draft-ietf-vcon-vcon-core-03.html) requires.
- Concretely: for a call with a single transfer (customer + 2 agent legs), the final `dialog` array is `[recording, transfer, recording]` — the old code set `target_dialog: 1`, pointing at the transfer object itself rather than the destination recording (actually at index `2`).
- Fix: derive both indices from `length(acc)` at the point of insertion — `prev_dialog` is always the last element already in `acc`, and `next_dialog` lands right after the transfer object being appended, so those lengths give the dialogs' real positions in the array actually being built.

## Test plan
- [x] `mix compile --warnings-as-errors` passes
- [x] Manually verified against a 3-leg (customer + 2 agents) transfer scenario: `target_dialog` now resolves to `2` (the destination recording) instead of `1` (the transfer object itself); `original` still correctly resolves to `0`