### PR TITLE
Move server images from Debian bullseye to bookworm

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -78,7 +78,7 @@ services:
       - comcent-network
 
   server:
-    image: hexpm/elixir:1.18.3-erlang-27.3-debian-bullseye-20250317-slim
+    image: hexpm/elixir:1.18.3-erlang-27.3-debian-bookworm-20250317-slim
     ports:
       - '5400:4000'
     env_file:

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -7,13 +7,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20250317-slim - for the release image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm-20250317-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.18.3-erlang-27.3-debian-bullseye-20250317-slim
+#   - Ex: hexpm/elixir:1.18.3-erlang-27.3-debian-bookworm-20250317-slim
 #
 ARG ELIXIR_VERSION=1.18.3
 ARG OTP_VERSION=27.3
-ARG DEBIAN_VERSION=bullseye-20250317-slim
+ARG DEBIAN_VERSION=bookworm-20250317-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
@@ -28,6 +28,11 @@ RUN apt-get update -y && apt-get install -y build-essential git \
 WORKDIR /app
 
 # install hex + rebar
+# hex.pm is served via a CDN whose edges are sometimes very slow (~19s per
+# request observed), which exceeds Hex's default timeout and fails the build
+# with a bare ":timeout".
+ENV HEX_HTTP_TIMEOUT=180
+
 RUN mix local.hex --force && \
   mix local.rebar --force
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,13 +7,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20250317-slim - for the release image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm-20250317-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.18.3-erlang-27.3-debian-bullseye-20250317-slim
+#   - Ex: hexpm/elixir:1.18.3-erlang-27.3-debian-bookworm-20250317-slim
 #
 ARG ELIXIR_VERSION=1.18.3
 ARG OTP_VERSION=27.3
-ARG DEBIAN_VERSION=bullseye-20250317-slim
+ARG DEBIAN_VERSION=bookworm-20250317-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
## Why

Debian 11 bullseye's security index advertises package versions its mirror no longer serves, so `apt-get install` fails with a 404 inside the container, on both amd64 and arm64:

```
E: Failed to fetch .../libperl5.32_5.32.1-4+deb11u5_amd64.deb  404  Not Found
E: Unable to fetch some archives
```

The server container installs `build-essential git curl` at startup, and that install had been **failing silently**. The visible symptom is subtle: no `curl` in the image means the compose healthcheck can never pass, because it probes `/health` with `curl`:

```yaml
test: ['CMD', 'curl', '--fail', '--silent', 'http://127.0.0.1:4000/health']
```

The container then sits permanently `unhealthy` even though the app is serving fine, and anything gated on `condition: service_healthy` never starts.

Bookworm installs those packages cleanly, so this fixes the cause rather than clearing the apt cache on every boot.

## Changes

- `DEBIAN_VERSION` bullseye → bookworm in `server/Dockerfile` and `docker/Dockerfile-server`, plus the hardcoded tag in `docker-compose.yaml`
- `HEX_HTTP_TIMEOUT=180` in the release image

## Notable

`DEBIAN_VERSION` drives both `BUILDER_IMAGE` and `RUNNER_IMAGE`, so both tags had to exist — confirmed before switching.

The Hex timeout is separate: hex.pm is served via a CDN whose edges can take ~19s per request (measured on both IPv4 and IPv6). That exceeds Hex's default timeout and fails the build with a bare `:timeout` during `mix deps.get`, which is easy to misread as a lockfile problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)